### PR TITLE
9150: reworked the map position in a geographic response

### DIFF
--- a/app/assets/stylesheets/local/responses/hierarchical_form/_question_types.scss
+++ b/app/assets/stylesheets/local/responses/hierarchical_form/_question_types.scss
@@ -1,10 +1,10 @@
 .response-form {
   .answer-map {
     display: none;
-    float: $right;
-    height: 80px;
+    height: 90px;
     margin-bottom: 10px;
-    width: 160px;
+    margin-top: 10px;
+    width: 180px;
   }
 
   .qtype-long-text {

--- a/app/views/responses/answers/_single_read_only.html.erb
+++ b/app/views/responses/answers/_single_read_only.html.erb
@@ -4,9 +4,9 @@
 
    when 'select_one' %>
 
-  <%= render('responses/answers/map', answer: answer) if answer.coordinates? %>
-
   <%= content_tag(:div, answer.option.try(:name), data: {val: [answer.option_node_id]}) %>
+
+  <%= render('responses/answers/map', answer: answer) if answer.coordinates? %>
 
 <% when 'select_multiple' %>
 


### PR DESCRIPTION
It used to be a float, but thought it would be better just inline, rather than to the right. See before and after.
Before:
![image](https://user-images.githubusercontent.com/989482/49894206-5943fc80-fe1b-11e8-87e5-4efbd68fdfff.png)

After:
![image](https://user-images.githubusercontent.com/989482/49894132-2a2d8b00-fe1b-11e8-899b-79acf4499b89.png)
