### PR TITLE
9540: Add warnings when regenerating keys

### DIFF
--- a/app/assets/javascripts/views/settings_view.js.coffee
+++ b/app/assets/javascripts/views/settings_view.js.coffee
@@ -5,8 +5,8 @@ class ELMO.Views.SettingsView extends ELMO.Views.ApplicationView
   events:
     'click #external_sql .control a': 'select_external_sql'
     'click .adapter-settings a.show-credential-fields': 'show_change_credential_fields'
-    'click .using-incoming_sms_token': 'show_using_incoming_sms_token_modal'
-    'click .using-universal_sms_token': 'show_using_universal_sms_token_modal'
+    'click .using-incoming-sms-token': 'show_using_incoming_sms_token_modal'
+    'click .using-universal-sms-token': 'show_using_universal_sms_token_modal'
     'click .credential-fields input[type=checkbox]:checked': 'clear_sms_fields'
 
   initialize: (options) ->

--- a/app/assets/javascripts/views/using_incoming_sms_token_view.js.coffee
+++ b/app/assets/javascripts/views/using_incoming_sms_token_view.js.coffee
@@ -1,5 +1,5 @@
 class ELMO.Views.UsingIncomingSmsTokenModalView extends ELMO.Views.ApplicationView
-  el: '#using-incoming_sms_token-modal'
+  el: '#using-incoming-sms-token-modal'
 
   initialize: (options) ->
     @$('.modal-body').html(options.html)

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -23,7 +23,6 @@
     <%= f.field(:default_outgoing_sms_adapter, type: :select,
       options: @adapter_options, prompt: t("common.none")) %>
 
-
     <h2 class="mt-4"><%= t("setting.headings.frontlinecloud") %></h2>
     <div class="adapter-settings" data-adapter="FrontlineCloud">
 

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -6,7 +6,7 @@
   <%= f.field(:theme, type: :select, options: Setting.theme_options, required: true, prompt: false) %>
   <% if configatron.has_key?(:universal_sms_token) %>
     <%= f.regenerable_field(:universal_sms_token, no_button: true,
-      append: link_to(t("setting.using_incoming_sms_token"), "#", class: "using-universal_sms_token")) %>
+      append: link_to(t("setting.using_incoming_sms_token"), "#", class: "using-universal-sms-token")) %>
   <% end %>
 
   <%# None of the rest of this is relevant in admin mode. %>
@@ -18,7 +18,7 @@
     <%= f.field(:incoming_sms_numbers_str, type: :textarea) %>
 
     <%= f.regenerable_field(:incoming_sms_token, confirm: t("setting.sms_token_warning"),
-      append: link_to(t("setting.using_incoming_sms_token"), "#", class: "using-incoming_sms_token")) %>
+      append: link_to(t("setting.using_incoming_sms_token"), "#", class: "using-incoming-sms-token")) %>
 
     <%= f.field(:default_outgoing_sms_adapter, type: :select,
       options: @adapter_options, prompt: t("common.none")) %>
@@ -64,7 +64,7 @@
 <% end %>
 
 <%# using incoming_sms_token modal %>
-<div class="modal fade" id="using-incoming_sms_token-modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade" id="using-incoming-sms-token-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -6,19 +6,19 @@
   <%= f.field(:theme, type: :select, options: Setting.theme_options, required: true, prompt: false) %>
   <% if configatron.has_key?(:universal_sms_token) %>
     <%= f.regenerable_field(:universal_sms_token, no_button: true,
-      append: link_to(t('setting.using_incoming_sms_token'), '#', class: 'using-universal_sms_token')) %>
+      append: link_to(t("setting.using_incoming_sms_token"), "#", class: "using-universal_sms_token")) %>
   <% end %>
 
   <%# None of the rest of this is relevant in admin mode. %>
   <% unless admin_mode? %>
-    <%= f.regenerable_field(:override_code, confirm: t('setting.override_code_warning')) %>
+    <%= f.regenerable_field(:override_code, confirm: t("setting.override_code_warning")) %>
 
     <h2 class="mt-4"><%= t("setting.headings.sms") %></h2>
 
     <%= f.field(:incoming_sms_numbers_str, type: :textarea) %>
 
-    <%= f.regenerable_field(:incoming_sms_token, confirm: t('setting.sms_token_warning'),
-      append: link_to(t('setting.using_incoming_sms_token'), '#', class: 'using-incoming_sms_token')) %>
+    <%= f.regenerable_field(:incoming_sms_token, confirm: t("setting.sms_token_warning"),
+      append: link_to(t("setting.using_incoming_sms_token"), "#", class: "using-incoming_sms_token")) %>
 
     <%= f.field(:default_outgoing_sms_adapter, type: :select,
       options: @adapter_options, prompt: t("common.none")) %>
@@ -27,11 +27,11 @@
     <h2 class="mt-4"><%= t("setting.headings.frontlinecloud") %></h2>
     <div class="adapter-settings" data-adapter="FrontlineCloud">
 
-      <%= link_to(t("setting.change_api_key"), "#", class: 'show-credential-fields') %>
+      <%= link_to(t("setting.change_api_key"), "#", class: "show-credential-fields") %>
 
       <div class="credential-fields">
         <%= f.field(:frontlinecloud_api_key1, type: :password) %>
-        <%= f.field(:clear_frontlinecloud, type: :check_box, label: t('common.clear')) %>
+        <%= f.field(:clear_frontlinecloud, type: :check_box, label: t("common.clear")) %>
       </div>
     </div>
 
@@ -40,11 +40,11 @@
       <%= f.field(:twilio_phone_number) %>
 
       <%= f.field(:twilio_account_sid,
-        append: link_to(t("setting.change_twilio_auth_token"), "#", class: 'show-credential-fields')) %>
+        append: link_to(t("setting.change_twilio_auth_token"), "#", class: "show-credential-fields")) %>
 
       <div class="credential-fields">
         <%= f.field(:twilio_auth_token1, type: :password) %>
-        <%= f.field(:clear_twilio, type: :check_box, label: t('common.clear')) %>
+        <%= f.field(:clear_twilio, type: :check_box, label: t("common.clear")) %>
       </div>
     </div>
 
@@ -68,7 +68,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h4 class="modal-title"><%= t('activerecord.hints.setting.using_incoming_sms_token_title') %></h4>
+        <h4 class="modal-title"><%= t("activerecord.hints.setting.using_incoming_sms_token_title") %></h4>
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
       </div>
       <div class="modal-body pane_body"></div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -17,7 +17,7 @@
 
     <%= f.field(:incoming_sms_numbers_str, type: :textarea) %>
 
-    <%= f.regenerable_field(:incoming_sms_token,
+    <%= f.regenerable_field(:incoming_sms_token, confirm: t('setting.sms_token_warning'),
       append: link_to(t('setting.using_incoming_sms_token'), '#', class: 'using-incoming_sms_token')) %>
 
     <%= f.field(:default_outgoing_sms_adapter, type: :select,

--- a/app/views/users/form.html.erb
+++ b/app/views/users/form.html.erb
@@ -48,8 +48,10 @@
       <%= f.field(:password_confirmation, type: :password) %>
     </div>
   <% end %>
-  <%= f.regenerable_field(:api_key) if !@user.new_record? && can?(:regenerate_api_key, @user) %>
-  <%= f.regenerable_field(:sms_auth_code) if !@user.new_record? && can?(:regenerate_sms_auth_code, @user) %>
+  <%= f.regenerable_field(:api_key, confirm: t('setting.api_key_warning')) if
+          !@user.new_record? && can?(:regenerate_api_key, @user) %>
+  <%= f.regenerable_field(:sms_auth_code, confirm: t('setting.sms_auth_code_warning')) if
+          !@user.new_record? && can?(:regenerate_sms_auth_code, @user) %>
   <div class="submit-buttons">
     <%= f.submit(class: "btn btn-primary") %>
   </div>

--- a/app/views/users/form.html.erb
+++ b/app/views/users/form.html.erb
@@ -48,10 +48,12 @@
       <%= f.field(:password_confirmation, type: :password) %>
     </div>
   <% end %>
-  <%= f.regenerable_field(:api_key, confirm: t("setting.api_key_warning")) if
-          !@user.new_record? && can?(:regenerate_api_key, @user) %>
-  <%= f.regenerable_field(:sms_auth_code, confirm: t("setting.sms_auth_code_warning")) if
-          !@user.new_record? && can?(:regenerate_sms_auth_code, @user) %>
+  <% if !@user.new_record? && can?(:regenerate_api_key, @user) %>
+    <%= f.regenerable_field(:api_key, confirm: t("setting.api_key_warning")) %>
+  <% end %>
+  <% if !@user.new_record? && can?(:regenerate_sms_auth_code, @user) %>
+    <%= f.regenerable_field(:sms_auth_code, confirm: t("setting.sms_auth_code_warning")) %>
+  <% end %>
   <div class="submit-buttons">
     <%= f.submit(class: "btn btn-primary") %>
   </div>

--- a/app/views/users/form.html.erb
+++ b/app/views/users/form.html.erb
@@ -1,6 +1,6 @@
 <%# special title if user is editing self %>
-<% @title_args = {name: @user.name || ''} %>
-<% @title_args[:name] += " (#{t('common.inactive')})" if !@user.active? %>
+<% @title_args = {name: @user.name || ""} %>
+<% @title_args[:name] += " (#{t("common.inactive")})" if !@user.active? %>
 <% @title = t("page_titles.users.#{form_mode}_profile", name: @user.name) if @user == current_user %>
 
 <%= elmo_form_for(@user) do |f| %>
@@ -48,9 +48,9 @@
       <%= f.field(:password_confirmation, type: :password) %>
     </div>
   <% end %>
-  <%= f.regenerable_field(:api_key, confirm: t('setting.api_key_warning')) if
+  <%= f.regenerable_field(:api_key, confirm: t("setting.api_key_warning")) if
           !@user.new_record? && can?(:regenerate_api_key, @user) %>
-  <%= f.regenerable_field(:sms_auth_code, confirm: t('setting.sms_auth_code_warning')) if
+  <%= f.regenerable_field(:sms_auth_code, confirm: t("setting.sms_auth_code_warning")) if
           !@user.new_record? && can?(:regenerate_sms_auth_code, @user) %>
   <div class="submit-buttons">
     <%= f.submit(class: "btn btn-primary") %>

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -2067,7 +2067,7 @@ en:
     change_twilio_auth_token: "Change Auth Token"
     change_api_key: "Change API Key"
     override_code_warning: "Note that the new override code will not work with forms that have already been downloaded. You should record the existing code if this is a problem. Are you sure you want to regenerate the code?"
-    sms_token_warning: "Note that this will invalidate the previous SMS token for this mission. Are you sure you want to regenerate the token?"
+    sms_token_warning: "Note that this will invalidate the previous SMS token for this mission. All incoming SMSes will be rejected until your SMS gateway settings are updated accordingly. Are you sure you want to regenerate the token?"
     api_key_warning: "Note that this will invalidate the previous API key for this user. Are you sure you want to regenerate the key?"
     sms_auth_code_warning: "Note that this will invalidate the previous SMS auth code for this user. Are you sure you want to regenerate the code?"
     using_incoming_sms_token: "How do I use this?"

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -2067,6 +2067,9 @@ en:
     change_twilio_auth_token: "Change Auth Token"
     change_api_key: "Change API Key"
     override_code_warning: "Note that the new override code will not work with forms that have already been downloaded. You should record the existing code if this is a problem. Are you sure you want to regenerate the code?"
+    sms_token_warning: "Note that this will invalidate the previous SMS token for this mission. Are you sure you want to regenerate the token?"
+    api_key_warning: "Note that this will invalidate the previous API key for this user. Are you sure you want to regenerate the key?"
+    sms_auth_code_warning: "Note that this will invalidate the previous SMS auth code for this user. Are you sure you want to regenerate the code?"
     using_incoming_sms_token: "How do I use this?"
     headings:
       general: "General Settings"

--- a/spec/features/settings/settings_regenerable_field_spec.rb
+++ b/spec/features/settings/settings_regenerable_field_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "settings regenerable fields", js: true do
+  include_context "regenerable fields"
+
+  let!(:user) { create(:user) }
+  let!(:mission) { get_mission }
+
+  before do
+    login(user)
+  end
+
+  describe "override code" do
+    scenario "can regenerate" do
+      visit("/en/m/#{mission.compact_name}/settings")
+      expect_token_generated(".setting_override_code")
+      expect_token_regenerated(".setting_override_code")
+    end
+  end
+
+  describe "incoming sms token" do
+    scenario "can regenerate" do
+      visit("/en/m/#{mission.compact_name}/settings")
+      emails = emails_sent_by { expect_token_regenerated(".setting_incoming_sms_token") }
+      expect(emails.length).to eq(1)
+
+      email = emails.first
+      expect(email.body.to_s).to match(/#{mission.name}/)
+      expect(email.body.to_s).not_to match(/translation_missing/)
+    end
+  end
+end

--- a/spec/features/users/user_form_spec.rb
+++ b/spec/features/users/user_form_spec.rb
@@ -25,11 +25,12 @@ feature "user form", js: true do
       fill_in("Alternate Phone", with: "+2347033772211")
       select("Enumerator", from: "user_assignments_attributes_0_role")
       select("Send password reset instructions via email", from: "user_reset_password_method")
-      click_button("Save")
+      emails = emails_sent_by { click_button("Save") }
       expect(page).to have_content("Success: User created successfully")
 
       # Make sure password email url is correct and no missing translations
-      email = ActionMailer::Base.deliveries.last
+      expect(emails.length).to eq(1)
+      email = emails.first
       expect(email.body.to_s).to match(%r{^https?://.+/en/password-resets/[\w_-]+/edit$})
       expect(email.body.to_s).not_to match(/translation_missing/)
 

--- a/spec/features/users/user_regenerable_field_spec.rb
+++ b/spec/features/users/user_regenerable_field_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "user regenerable fields", js: true do
+  include_context "regenerable fields"
+
+  let!(:user) { create(:user) }
+  let!(:mission) { get_mission }
+
+  before do
+    login(user)
+  end
+
+  describe "api key" do
+    scenario "can regenerate" do
+      visit("/en/m/#{mission.compact_name}/users/#{user.id}/edit")
+      expect_token_regenerated(".user_api_key")
+    end
+  end
+
+  describe "sms auth code" do
+    scenario "can regenerate" do
+      visit("/en/m/#{mission.compact_name}/users/#{user.id}/edit")
+      expect_token_regenerated(".user_sms_auth_code")
+    end
+  end
+end

--- a/spec/requests/api_key_field_spec.rb
+++ b/spec/requests/api_key_field_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: Most of these tests should live in authorization specs instead.
+#   Please move at the next opportunity.
 describe 'api key form field', database_cleaner: :all do
 
   before(:all) do

--- a/spec/requests/sms_auth_code_field_spec.rb
+++ b/spec/requests/sms_auth_code_field_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
+# TODO: Most of these tests should live in authorization specs instead.
+#   Please move at the next opportunity.
 describe "sms auth code field", :sms, database_cleaner: :all do
 
   before(:all) do

--- a/spec/support/contexts/regenerable_fields.rb
+++ b/spec/support/contexts/regenerable_fields.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Provides spec helper methods for dealing with regenerable fields.
+shared_context "regenerable fields" do
+  def expect_token_regenerated(class_name)
+    within(class_name) do
+      token = find(".regenerable-field span").text
+      accept_confirm { click_on("Regenerate") }
+      expect(page).to have_css(".fa-check-circle")
+      expect(find(".regenerable-field span").text).not_to eq(token)
+    end
+  end
+end

--- a/spec/support/contexts/regenerable_fields.rb
+++ b/spec/support/contexts/regenerable_fields.rb
@@ -2,6 +2,15 @@
 
 # Provides spec helper methods for dealing with regenerable fields.
 shared_context "regenerable fields" do
+  def expect_token_generated(class_name)
+    within(class_name) do
+      token = find(".regenerable-field span").text
+      click_on("Generate")
+      expect(page).to have_css(".fa-check-circle")
+      expect(find(".regenerable-field span").text).not_to eq(token)
+    end
+  end
+
   def expect_token_regenerated(class_name)
     within(class_name) do
       token = find(".regenerable-field span").text

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -122,4 +122,11 @@ module FeatureSpecHelpers
     # assert that the original select field was updated with the intended value
     select(value, options)
   end
+
+  # Returns all emails sent by the given block.
+  def emails_sent_by
+    old_count = ActionMailer::Base.deliveries.size
+    yield
+    ActionMailer::Base.deliveries[old_count..-1] || []
+  end
 end


### PR DESCRIPTION
To-do:
- [x] Rebase after `9546_token_change_email` (view [real diff](https://github.com/thecartercenter/nemo/compare/9546_token_change_email...9540_regenerate_warnings))
