### PR TITLE
9700: Don't allow filtering by the current question

### DIFF
--- a/app/javascript/components/DisplayLogicFormField.js
+++ b/app/javascript/components/DisplayLogicFormField.js
@@ -26,7 +26,7 @@ class DisplayLogicFormFieldRoot extends React.Component {
   constructor(props) {
     super(props);
     const { conditionSetStore, refableQings, id, type, displayIf, displayConditions, formId } = this.props;
-    this.state = { refableQings, type, displayIf };
+    this.state = { displayIf };
 
     // Directly assign initial values to the store.
     Object.assign(conditionSetStore, {
@@ -50,7 +50,7 @@ class DisplayLogicFormFieldRoot extends React.Component {
   }
 
   displayIfOptionTags = () => {
-    const { type } = this.state;
+    const { type } = this.props;
     const displayIfOptions = ['always', 'all_met', 'any_met'];
     return displayIfOptions.map((option) => (
       <option
@@ -63,7 +63,8 @@ class DisplayLogicFormFieldRoot extends React.Component {
   }
 
   render() {
-    const { refableQings, type, displayIf } = this.state;
+    const { refableQings, type } = this.props;
+    const { displayIf } = this.state;
 
     if (refableQings.length === 0) {
       return (

--- a/app/javascript/components/DisplayLogicFormField.js
+++ b/app/javascript/components/DisplayLogicFormField.js
@@ -26,7 +26,7 @@ class DisplayLogicFormFieldRoot extends React.Component {
   constructor(props) {
     super(props);
     const { conditionSetStore, refableQings, id, type, displayIf, displayConditions, formId } = this.props;
-    this.state = { refableQings, id, type, displayIf };
+    this.state = { refableQings, type, displayIf };
 
     // Directly assign initial values to the store.
     Object.assign(conditionSetStore, {
@@ -36,7 +36,8 @@ class DisplayLogicFormFieldRoot extends React.Component {
       conditions: displayConditions,
       conditionableId: id,
       conditionableType: 'FormItem',
-      refableQings,
+      // Display logic conditions can't reference self, as that doesn't make sense.
+      refableQings: refableQings.filter((qing) => qing.id !== id),
       hide: displayIf === 'always',
     });
   }
@@ -62,9 +63,7 @@ class DisplayLogicFormFieldRoot extends React.Component {
   }
 
   render() {
-    const { refableQings: rawRefableQings, id, type, displayIf } = this.state;
-    // Display logic conditions can't reference self, as that doesn't make sense.
-    const refableQings = rawRefableQings.filter((qing) => qing.id !== id);
+    const { refableQings, type, displayIf } = this.state;
 
     if (refableQings.length === 0) {
       return (

--- a/app/javascript/components/SkipLogicFormField.js
+++ b/app/javascript/components/SkipLogicFormField.js
@@ -12,9 +12,9 @@ class SkipLogicFormField extends React.Component {
 
   constructor(props) {
     super(props);
-    const { type, skipRules } = this.props;
+    const { skipRules } = this.props;
     const skip = skipRules.length === 0 ? 'dont_skip' : 'skip';
-    this.state = { type, skip };
+    this.state = { skip };
   }
 
   skipOptionChanged = (event) => {
@@ -34,7 +34,8 @@ class SkipLogicFormField extends React.Component {
   }
 
   render() {
-    const { skip, type } = this.state;
+    const { type } = this.props;
+    const { skip } = this.state;
     const selectProps = {
       className: 'form-control skip-or-not',
       value: skip,

--- a/app/javascript/components/SkipRuleFormField.js
+++ b/app/javascript/components/SkipRuleFormField.js
@@ -37,7 +37,6 @@ class SkipRuleFormFieldRoot extends React.Component {
       namePrefix,
       remove,
       id,
-      laterItems,
       skipIf,
       conditions,
       refableQings,
@@ -49,8 +48,6 @@ class SkipRuleFormFieldRoot extends React.Component {
 
     this.state = {
       remove,
-      id,
-      laterItems,
       skipIf,
       destItemIdOrEnd,
       destination,
@@ -117,10 +114,8 @@ class SkipRuleFormFieldRoot extends React.Component {
   }
 
   render() {
-    const { namePrefix, ruleId } = this.props;
-    const {
-      id, destItemIdOrEnd, laterItems, skipIf, destination, destItemId,
-    } = this.state;
+    const { id, laterItems, namePrefix, ruleId } = this.props;
+    const { destItemIdOrEnd, skipIf, destination, destItemId } = this.state;
     const idFieldProps = {
       type: 'hidden',
       name: `${namePrefix}[id]`,

--- a/app/javascript/components/SkipRuleSetFormField.js
+++ b/app/javascript/components/SkipRuleSetFormField.js
@@ -19,8 +19,8 @@ class SkipRuleSetFormField extends React.Component {
 
   constructor(props) {
     super(props);
-    const { skipRules, formId, laterItems, type, refableQings } = this.props;
-    this.state = { skipRules, formId, laterItems, type, refableQings };
+    const { skipRules } = this.props;
+    this.state = { skipRules };
   }
 
   // If about to show the set and it's empty, add a blank one.
@@ -33,7 +33,7 @@ class SkipRuleSetFormField extends React.Component {
   }
 
   handleAddClick = () => {
-    const { laterItems } = this.state;
+    const { laterItems } = this.props;
     const laterItemsExist = laterItems.length > 0;
     this.setState(({ skipRules }) => ({
       skipRules: skipRules.concat([{
@@ -46,8 +46,8 @@ class SkipRuleSetFormField extends React.Component {
   }
 
   render() {
-    const { hide } = this.props;
-    const { skipRules, formId, laterItems, type, refableQings } = this.state;
+    const { hide, formId, laterItems, type, refableQings } = this.props;
+    const { skipRules } = this.state;
 
     return (
       <div


### PR DESCRIPTION
Strange this fix was so easy, I repro'd it on v9.10 so I figured it would be something more than this.

Also includes a small cleanup of all React components to make sure the vars saved into `state` are actually changed by `setState`; otherwise keep them in `props` for clarity.