### PR TITLE
9722 fix assets:precompile in prod

### DIFF
--- a/app/assets/javascripts/legacy/url_builder.js
+++ b/app/assets/javascripts/legacy/url_builder.js
@@ -9,8 +9,10 @@
     this.mission_name = params.mission_name;
   };
 
-  klass.prototype.build = function (...args) {
-    let options = {};
+  klass.prototype.build = function () {
+    // we need some funky magic to turn the arguments object into an array
+    var args = Array.prototype.slice.call(arguments, 0);
+    var options = {};
 
     // If the last arg is an options hash, extract it.
     if (typeof args[args.length - 1] === 'object') {
@@ -23,21 +25,21 @@
     options.mode = options.mode || this.mode;
     options.mission_name = options.mission_name || this.mission_name;
 
-    const suffix = this.strip_scope(args.join('/'));
+    var suffix = this.strip_scope(args.join('/'));
 
-    let result;
+    var result;
     switch (options.mode) {
       case 'basic':
-        result = `/${options.locale}/${suffix}`;
+        result = '/' + options.locale + '/' + suffix;
         break;
       case 'mission':
-        result = `/${options.locale}/m/${options.mission_name}/${suffix}`;
+        result = '/' + options.locale + '/m/' + options.mission_name + '/' + suffix;
         break;
       case 'admin':
-        result = `/${options.locale}/admin/${suffix}`;
+        result = '/' + options.locale + '/admin/' + suffix;
         break;
       default:
-        throw new Error(`Invalid mode: ${options.mode}`);
+        throw new Error('Invalid mode: ' + options.mode);
     }
 
     // Return, fixing any double or trailing slashes.
@@ -46,16 +48,16 @@
 
   // Strip the locale and mission_name from the given path.
   klass.prototype.strip_scope = function (path) {
-    let modeMission;
-    if (this.mode === 'mission') modeMission = `m/${this.mission_name}`;
+    var modeMission;
+    if (this.mode === 'mission') modeMission = 'm/' + this.mission_name;
     else if (this.mode === 'admin') modeMission = 'admin';
     else modeMission = '';
 
     // Replace the "/en/", "/en/m/mission", "/en/m/mission/", "/en", and "/" variants with "/"...
-    if (!path || path.match(new RegExp(`^/([a-z]{2}(/${modeMission})?(/)?)?$`))) {
+    if (!path || path.match(new RegExp('^/([a-z]{2}(/' + modeMission + ')?(/)?)?$'))) {
       return '/';
     }
     // ...else fix the "/en/foo" or "/en/m/mission/foo" variants.
-    return path.replace(new RegExp(`^/[a-z]{2}(/${modeMission})?/(.+)`), (m, $1, $2) => `/${$2}`);
+    return path.replace(new RegExp('^/[a-z]{2}(/' + modeMission + ')?/(.+)'), function (m, $1, $2) { return '/' + $2; });
   };
 }(ELMO));

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   },
   "dependencies": {
     "@rails/webpacker": "3.5",
+    "babel-eslint": "10.0.1",
+    "babel-jest": "23.6.0",
+    "babel-plugin-transform-decorators-legacy": "1.3.5",
+    "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-react": "^6.24.1",
     "jquery": "3.3.1",
     "lodash": "4.17.11",
@@ -41,10 +45,6 @@
     "react_ujs": "^2.4.4"
   },
   "devDependencies": {
-    "babel-eslint": "10.0.1",
-    "babel-jest": "23.6.0",
-    "babel-plugin-transform-decorators-legacy": "1.3.5",
-    "babel-plugin-transform-runtime": "6.23.0",
     "coffeelint": "2.1.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.11.2",


### PR DESCRIPTION
To allow deploy. See commit messages for details.

Changes to `url_builder` are from this revert point: https://github.com/thecartercenter/nemo/blob/af33ed863b2479471b5d9517b408f7e28c135227%5E/app/assets/javascripts/legacy/url_builder.js.

Deployed successfully on staging.