### PR TITLE
9623 apply filter on dismiss

### DIFF
--- a/app/javascript/components/Filters/FilterOverlayTrigger/__snapshots__/component.test.js.snap
+++ b/app/javascript/components/Filters/FilterOverlayTrigger/__snapshots__/component.test.js.snap
@@ -4,6 +4,7 @@ exports[`renders as expected 1`] = `
 <OverlayTrigger
   containerPadding={25}
   id="id"
+  onExit={[Function]}
   overlay={
     <FilterPopover
       buttonsContainerClass="buttonsContainer"

--- a/app/javascript/components/Filters/FilterOverlayTrigger/component.js
+++ b/app/javascript/components/Filters/FilterOverlayTrigger/component.js
@@ -18,6 +18,12 @@ class FilterOverlayTrigger extends React.Component {
     buttonClass: PropTypes.string,
   };
 
+  handleExit = () => {
+    const { onSubmit } = this.props;
+    // TODO: Don't search if nothing was modified.
+    onSubmit();
+  }
+
   renderPopover = () => {
     const { id, popoverContent, popoverClass, buttonsContainerClass, onSubmit } = this.props;
 
@@ -43,6 +49,7 @@ class FilterOverlayTrigger extends React.Component {
         overlay={this.renderPopover()}
         placement="bottom"
         rootClose
+        onExit={this.handleExit}
         trigger="click"
       >
         <Button id={id} variant="secondary" className={buttonClass}>

--- a/app/javascript/components/Filters/FilterOverlayTrigger/component.js
+++ b/app/javascript/components/Filters/FilterOverlayTrigger/component.js
@@ -2,12 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import { inject, observer } from 'mobx-react';
 
 import { getButtonHintString } from '../utils';
 import FilterPopover from '../FilterPopover/component';
 
+@inject('filtersStore')
+@observer
 class FilterOverlayTrigger extends React.Component {
   static propTypes = {
+    filtersStore: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     popoverContent: PropTypes.node.isRequired,
@@ -19,9 +23,10 @@ class FilterOverlayTrigger extends React.Component {
   };
 
   handleExit = () => {
-    const { onSubmit } = this.props;
-    // TODO: Don't search if nothing was modified.
-    onSubmit();
+    const { filtersStore, onSubmit } = this.props;
+    if (filtersStore.isDirty) {
+      onSubmit();
+    }
   }
 
   renderPopover = () => {

--- a/app/javascript/components/Filters/FilterOverlayTrigger/component.test.js
+++ b/app/javascript/components/Filters/FilterOverlayTrigger/component.test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import Component from './component';
 
 const defaultProps = {
+  filtersStore: {},
   id: 'id',
   title: 'title',
   popoverContent: 'content',

--- a/app/javascript/components/Filters/model.js
+++ b/app/javascript/components/Filters/model.js
@@ -1,5 +1,6 @@
 import isEmpty from 'lodash/isEmpty';
 import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 import { action, observable, computed, reaction, toJS } from 'mobx';
 
 import ConditionSetModel from '../conditions/ConditionSetFormField/model';
@@ -48,6 +49,18 @@ class FiltersModel {
   @computed
   get selectedFormId() {
     return isEmpty(this.selectedFormIds) ? '' : this.selectedFormIds[0];
+  }
+
+  /** Returns true if the user may have modified any values (conservative). */
+  @computed
+  get isDirty() {
+    const clean = (
+      isEqual(this.original.selectedFormIds, this.selectedFormIds)
+      && isEqual(this.original.isReviewed, this.isReviewed)
+      && isEqual(this.original.selectedSubmittersForType, this.selectedSubmittersForType)
+      && !this.conditionSetStore.isDirty
+    );
+    return !clean;
   }
 
   constructor(initialState = {}) {

--- a/app/javascript/components/conditions/ConditionSetFormField/model.js
+++ b/app/javascript/components/conditions/ConditionSetFormField/model.js
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 import { observable, action, reaction, computed } from 'mobx';
 
 import ConditionModel from './ConditionFormField/model';
@@ -43,10 +44,16 @@ class ConditionSetModel {
   @observable
   forceRightSideLiteral = false;
 
-  // Get the number of non-deleted conditions in the set.
+  /** Returns the number of non-deleted conditions in the set. */
   @computed
   get conditionCount() {
     return this.conditions.reduce((sum, condition) => sum + (condition.remove ? 0 : 1), 0);
+  }
+
+  /** Returns true if the user may have modified any values (conservative). */
+  @computed
+  get isDirty() {
+    return !isEqual(this.original.conditions, this.conditions);
   }
 
   constructor(initialState = {}) {
@@ -57,9 +64,9 @@ class ConditionSetModel {
     });
 
     reaction(
-      () => this.original,
-      (original) => {
-        this.original.conditions = this.prepareConditions(original.conditions);
+      () => this.original.conditions,
+      (conditions) => {
+        this.original.conditions = this.prepareConditions(conditions);
       },
       { fireImmediately: true },
     );


### PR DESCRIPTION
Integration tests still coming soon after user-facing changes :)

Changes in this PR:
- Submit search automatically on dismiss popover
    - Only if something has been modified
    - In the case of the question filter, there's so much data to filter through it just makes a conservative judgment by deep-comparing the `conditions` array. If, for example, you change the condition and then revert it back, the conservative check will still assume something changed because of differing internal IDs and other modified metadata. Given the work required to do a full and accurate equality check, I say "good enough" to the conservative comparison.