### PR TITLE
9945 cascading select filter bug

### DIFF
--- a/app/javascript/components/Filters/QuestionFilter/component.js
+++ b/app/javascript/components/Filters/QuestionFilter/component.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react';
 
-import { getItemNameFromId } from '../utils';
+import { getItemNameFromId, getQuestionNameFromId } from '../utils';
 import ConditionSetFormField from '../../conditions/ConditionSetFormField/component';
 import AddConditionLink from '../../conditions/AddConditionLink/component';
 import FilterOverlayTrigger from '../FilterOverlayTrigger/component';
@@ -44,7 +44,7 @@ class QuestionFilter extends React.Component {
     const { original: { conditions, refableQings } } = conditionSetStore;
     const hints = conditions
       .filter(({ leftQingId }) => leftQingId)
-      .map(({ leftQingId }) => getItemNameFromId(refableQings, leftQingId, 'code'));
+      .map(({ leftQingId }) => getQuestionNameFromId(refableQings, leftQingId));
 
     return (
       <FilterOverlayTrigger

--- a/app/javascript/components/Filters/utils.js
+++ b/app/javascript/components/Filters/utils.js
@@ -62,8 +62,7 @@ export function getItemNameFromId(allItems, searchId, nameKey = 'name') {
  * Given a leftQingId, find it in the list of all questions and return the name.
  */
 export function getQuestionNameFromId(allQuestions, searchId) {
-  const question = allQuestions.find(({ id }) => searchId === id);
-  return (question && question.code) || 'Unknown';
+  return getItemNameFromId(allQuestions, searchId, 'code');
 }
 
 /**

--- a/app/javascript/components/conditions/ConditionSetFormField/ConditionFormField/model.js
+++ b/app/javascript/components/conditions/ConditionSetFormField/ConditionFormField/model.js
@@ -53,6 +53,31 @@ class ConditionModel {
   @observable
   remove;
 
+  /** Return either the current value or the value of the deepest defined level. */
+  @computed
+  get currTextValue() {
+    if (this.optionSetId) {
+      const lastIndex = this.levels.length - 1;
+
+      for (let i = lastIndex; i >= 0; i -= 1) {
+        const { selected, options } = this.levels[i];
+
+        if (selected != null) {
+          const { name = '' } = options.find(({ id }) => selected === id) || {};
+          return name;
+        }
+      }
+
+      return null;
+    } if (this.optionNodeId) {
+      // If optionSet hasn't been loaded (for example, if question filter popover
+      // hasn't yet been mounted), fall back to the string value passed by backend.
+      return this.optionNodeValue;
+    }
+
+    return this.value;
+  }
+
   constructor(initialState = {}) {
     Object.assign(this, initialState);
 
@@ -90,31 +115,6 @@ class ConditionModel {
       },
       { fireImmediately: true },
     );
-  }
-
-  /** Return either the current value or the value of the deepest defined level. */
-  @computed
-  get currTextValue() {
-    if (this.optionSetId) {
-      const lastIndex = this.levels.length - 1;
-
-      for (let i = lastIndex; i >= 0; i -= 1) {
-        const { selected, options } = this.levels[i];
-
-        if (selected != null) {
-          const { name = '' } = options.find(({ id }) => selected === id) || {};
-          return name;
-        }
-      }
-
-      return null;
-    } if (this.optionNodeId) {
-      // If optionSet hasn't been loaded (for example, if question filter popover
-      // hasn't yet been mounted), fall back to the string value passed by backend.
-      return this.optionNodeValue;
-    }
-
-    return this.value;
   }
 
   /**

--- a/app/javascript/components/conditions/ConditionSetFormField/ConditionFormField/model.js
+++ b/app/javascript/components/conditions/ConditionSetFormField/ConditionFormField/model.js
@@ -73,7 +73,7 @@ class ConditionModel {
       }
 
       return null;
-    } if (this.optionNodeId) {
+    } else if (this.optionNodeId) {
       // If optionSet hasn't been loaded (for example, if question filter popover
       // hasn't yet been mounted), fall back to the string value passed by backend.
       return this.optionNodeValue;

--- a/app/javascript/components/conditions/ConditionSetFormField/ConditionFormField/model.js
+++ b/app/javascript/components/conditions/ConditionSetFormField/ConditionFormField/model.js
@@ -53,12 +53,16 @@ class ConditionModel {
   @observable
   remove;
 
-  /** Return either the current value or the value of the deepest defined level. */
+  /**
+   * Return a string representation of the current value.
+   * Both user-facing and sent to the backend when performing a search.
+   */
   @computed
   get currTextValue() {
     if (this.optionSetId) {
       const lastIndex = this.levels.length - 1;
 
+      // Iterate back through each level, trying to find the deepest selected item.
       for (let i = lastIndex; i >= 0; i -= 1) {
         const { selected, options } = this.levels[i];
 

--- a/app/searchers/responses_searcher.rb
+++ b/app/searchers/responses_searcher.rb
@@ -265,10 +265,10 @@ class ResponsesSearcher < Searcher
 
   # Map possibilities to a single id based on any active form filters.
   def refine_qing_possibilities(qing)
-    return qing unless qing[:possibilities]
-    qings = Questioning.where(id: qing[:possibilities])
-    qings = qings.where(form_id: form_ids) if form_ids.present?
-    qing[:id] = qings.filter_unique.pluck(:id).first
+    possibilities = qing[:possibilities]
+    return qing unless possibilities
+    possibilities = possibilities.where(form_id: form_ids) if form_ids.present?
+    qing[:id] = possibilities.filter_unique.pluck(:id).first
     qing.except(:possibilities)
   end
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "enzyme-to-json": "3.3.5",
     "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.0",
-    "eslint-config-cooperka": "1.0.1",
+    "eslint-config-cooperka": "1.0.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.1",
     "eslint-plugin-react": "^7.11.0",

--- a/spec/searchers/responses_searcher_spec.rb
+++ b/spec/searchers/responses_searcher_spec.rb
@@ -9,6 +9,7 @@ describe ResponsesSearcher do
 
   describe "form qualifier" do
     let(:form2) { create(:form, name: "bar", question_types: %w[integer]) }
+    let(:form3) { create(:form, name: "qu'o`t\"es") }
     let!(:r1) { create(:response, form: form) }
     let!(:r2) { create(:response, form: form2) }
     let!(:r3) { create(:response, form: form) }
@@ -22,6 +23,7 @@ describe ResponsesSearcher do
       expect(searcher(%(form:BAR))).to have_filter_data(form_ids: [form2.id], advanced_text: "")
       expect(searcher(%(form:x))).to have_filter_data(form_ids: [], advanced_text: "form:x")
       expect(searcher(%(form:bar source:x))).to have_filter_data(form_ids: [form2.id], advanced_text: "source:x")
+      expect(searcher(%(form:(qu'o`t"es)))).to have_filter_data(form_ids: [form3.id])
     end
   end
 

--- a/spec/searchers/responses_searcher_spec.rb
+++ b/spec/searchers/responses_searcher_spec.rb
@@ -136,6 +136,7 @@ describe ResponsesSearcher do
 
   describe "question qualifier" do
     let(:form) { create(:form, question_types: %w[long_text long_text multilevel_select_one]) }
+    let(:form2) { create(:form) }
     let(:codes) { form.c[0..2].map(&:code) }
     let(:node3) { form.c[2].question.option_set.c[0] }
     let(:preferred_locales) { configatron.preferred_locales }
@@ -160,6 +161,16 @@ describe ResponsesSearcher do
       expect(searcher(%({#{codes[1].upcase}}:apple {#{codes[0].downcase}}:apple apple))).to have_filter_data(
         qings: [{id: form.c[1].id, value: "apple"}, {id: form.c[0].id, value: "apple"}],
         advanced_text: "apple"
+      )
+      expect(searcher(%({#{codes[0]}}:apple form:"#{form2.name}"))).to have_filter_data(
+        # This question doesn't exist on this form, so it won't be found.
+        qings: [{id: nil, value: "apple"}],
+        advanced_text: ""
+      )
+      expect(searcher(%({#{codes[0]}}:apple form:"#{form.name}"))).to have_filter_data(
+        # But it does exist on this form.
+        qings: [{id: form.c[0].id, value: "apple"}],
+        advanced_text: ""
       )
       expect(searcher(%({#{codes[2]}}:#{node3.option.canonical_name}))).to have_filter_data(
         qings: [{id: form.c[2].id, option_node_id: node3.id, option_node_value: node3.option.canonical_name}],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3154,10 +3154,10 @@ eslint-config-airbnb@17.1.0:
     object.assign "^4.1.0"
     object.entries "^1.0.4"
 
-eslint-config-cooperka@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-cooperka/-/eslint-config-cooperka-1.0.1.tgz#4311a067e79a28310440fd93b5c0daa8654c1a24"
-  integrity sha512-6y+a8KwWi8RgxIQBCTCAK2WuL2UoJXhU56X7dJGc+SAaJeN4cA9sdL6ks7AeKYz/xeM9nnApbb+y7qbtkAMxRQ==
+eslint-config-cooperka@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-cooperka/-/eslint-config-cooperka-1.0.2.tgz#9c2294bfe276102d545c20b550d4e79da778e42b"
+  integrity sha512-YH/kPPgLDtHrhEIiVTgRY3dcpMMsSOCRAYPwbsfQMvt7UiZHp253G4lWK0hyu2sP2PO19xGn4Mhb8/NZV26muQ==
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"


### PR DESCRIPTION
Bug description:
> If you filter by a form, then ALSO filter by a cascading question, then ALSO submit the search a third time WITHOUT opening the question popover first, the question value is `Unknown` and the search fails.

This PR:
- Fixes the bug by filtering `qings` by any selected `form_id`s before determining the `refableQing` ID to pass to the client
- Does some minor code cleanup

This is the last remaining piece needed before releasing the initial version of filters.