### PR TITLE
9909 filter media types

### DIFF
--- a/app/controllers/concerns/report_embeddable.rb
+++ b/app/controllers/concerns/report_embeddable.rb
@@ -15,10 +15,11 @@ module ReportEmbeddable
         attribs: Report::AttribField.all,
         forms: Form.for_mission(current_mission).by_name.as_json(only: %i[id name]),
         calculation_types: Report::Calculation::TYPES,
-        questions: Question.for_mission(current_mission).reportable.includes(:forms, :option_set).by_code.as_json(
-          only: %i[id code qtype_name],
-          methods: %i[form_ids geographic?]
-        ),
+        questions: Question.for_mission(current_mission).with_type_property(:reportable)
+          .includes(:forms, :option_set).by_code.as_json(
+            only: %i[id code qtype_name],
+            methods: %i[form_ids geographic?]
+          ),
         option_sets: OptionSet.for_mission(current_mission).by_name.as_json(only: %i[id name]),
         percent_types: Report::Report::PERCENT_TYPES,
 

--- a/app/controllers/concerns/report_embeddable.rb
+++ b/app/controllers/concerns/report_embeddable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # methods required to embed a report display in a page
 module ReportEmbeddable
   # sets up the @report_data structure which will be converted to json
@@ -11,13 +13,13 @@ module ReportEmbeddable
     unless options[:read_only]
       @report_data[:options] = {
         attribs: Report::AttribField.all,
-        forms: Form.for_mission(current_mission).by_name.as_json(only: [:id, :name]),
+        forms: Form.for_mission(current_mission).by_name.as_json(only: %i[id name]),
         calculation_types: Report::Calculation::TYPES,
         questions: Question.for_mission(current_mission).reportable.includes(:forms, :option_set).by_code.as_json(
-          only: [:id, :code, :qtype_name],
-          methods: [:form_ids, :geographic?]
+          only: %i[id code qtype_name],
+          methods: %i[form_ids geographic?]
         ),
-        option_sets: OptionSet.for_mission(current_mission).by_name.as_json(only: [:id, :name]),
+        option_sets: OptionSet.for_mission(current_mission).by_name.as_json(only: %i[id name]),
         percent_types: Report::Report::PERCENT_TYPES,
 
         # the names of qtypes that can be used in headers
@@ -39,16 +41,14 @@ module ReportEmbeddable
   #
   # returns true if no errors, false otherwise
   def run_or_fetch_and_handle_errors(options = {})
-    begin
-      @report = Rails.cache.fetch(cache_key_with_responses) do
-        @report.run(current_ability, options)
-        @report
-      end
-      true
-    rescue Report::ReportError, Search::ParseError
-      flash.now[:error] = $!.to_s
-      false
+    @report = Rails.cache.fetch(cache_key_with_responses) do
+      @report.run(current_ability, options)
+      @report
     end
+    true
+  rescue Report::ReportError, Search::ParseError
+    flash.now[:error] = $ERROR_INFO.to_s
+    false
   end
 
   def cache_key_with_responses
@@ -60,6 +60,6 @@ module ReportEmbeddable
 
       Response.per_mission_cache_key(current_mission),
       @report.cache_key
-    ].compact.join('-')
+    ].compact.join("-")
   end
 end

--- a/app/controllers/filter_data_controller.rb
+++ b/app/controllers/filter_data_controller.rb
@@ -9,7 +9,7 @@ class FilterDataController < ApplicationController
   def qings
     authorize!(:index, Response)
     qings = Questioning.for_mission(current_mission).joins(:question)
-      .includes(:question).order("questions.code")
+      .includes(:question).where(question: Question.reportable).order("questions.code")
     qings = qings.where(form_id: params[:form_ids]) if params[:form_ids].present?
     qings = qings.filter_unique
     render(json: ActiveModel::ArraySerializer.new(qings,

--- a/app/controllers/filter_data_controller.rb
+++ b/app/controllers/filter_data_controller.rb
@@ -9,7 +9,7 @@ class FilterDataController < ApplicationController
   def qings
     authorize!(:index, Response)
     qings = Questioning.for_mission(current_mission).joins(:question)
-      .includes(:question).where(question: Question.reportable).order("questions.code")
+      .includes(:question).with_type_property(:refable).order("questions.code")
     qings = qings.where(form_id: params[:form_ids]) if params[:form_ids].present?
     qings = qings.filter_unique
     render(json: ActiveModel::ArraySerializer.new(qings,

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -104,7 +104,9 @@ class Question < ApplicationRecord
   scope :default_order, -> { by_code }
   scope :select_types, -> { where(qtype_name: %w[select_one select_multiple]) }
   scope :with_forms, -> { includes(:forms) }
-  scope :reportable, -> { where.not(qtype_name: %w[image annotated_image signature sketch audio video]) }
+  scope :with_type_property, lambda { |property|
+    where(qtype_name: QuestionType.with_property(property).map(&:name))
+  }
   scope :not_in_form, lambda { |form|
                         where("(questions.id NOT IN (
                           SELECT question_id FROM form_items

--- a/app/models/question_type.rb
+++ b/app/models/question_type.rb
@@ -1,56 +1,56 @@
 class QuestionType
   AVAILABLE_PROPERTIES = %w[printable smsable textual headerable defaultable numeric
-                            multimedia temporal has_options has_timezone refable].freeze
+                            multimedia temporal has_options has_timezone refable reportable].freeze
   attr_reader :name, :odk_name, :properties
 
   @attributes = [{
     name: "text",
     odk_name: "string",
-    properties: %w[printable smsable textual headerable defaultable refable]
+    properties: %w[printable smsable textual headerable defaultable refable reportable]
   }, {
     name: "long_text",
     odk_name: "string",
-    properties: %w[printable smsable textual refable defaultable]
+    properties: %w[printable smsable textual refable defaultable reportable]
   }, {
     name: "barcode",
     odk_name: "barcode",
-    properties: %w[printable smsable textual refable]
+    properties: %w[printable smsable textual refable reportable]
   }, {
     name: "integer",
     odk_name: "int",
-    properties: %w[printable smsable numeric headerable refable defaultable]
+    properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "counter",
     odk_name: "int",
-    properties: %w[printable smsable numeric headerable refable defaultable]
+    properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "decimal",
     odk_name: "decimal",
-    properties: %w[printable smsable numeric headerable refable defaultable]
+    properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "location",
     odk_name: "geopoint",
-    properties: %w[]
+    properties: %w[reportable]
   }, {
     name: "select_one",
     odk_name: "select1",
-    properties: %w[printable has_options smsable headerable refable]
+    properties: %w[printable has_options smsable headerable refable reportable]
   }, {
     name: "select_multiple",
     odk_name: "select",
-    properties: %w[printable has_options smsable headerable refable]
+    properties: %w[printable has_options smsable headerable refable reportable]
   }, {
     name: "datetime",
     odk_name: "dateTime",
-    properties: %w[printable temporal has_timezone smsable headerable refable defaultable]
+    properties: %w[printable temporal has_timezone smsable headerable refable defaultable reportable]
   }, {
     name: "date",
     odk_name: "date",
-    properties: %w[printable temporal smsable headerable refable defaultable]
+    properties: %w[printable temporal smsable headerable refable defaultable reportable]
   }, {
     name: "time",
     odk_name: "time",
-    properties: %w[printable temporal smsable headerable refable defaultable]
+    properties: %w[printable temporal smsable headerable refable defaultable reportable]
   }, {
     name: "image",
     odk_name: "binary",

--- a/app/models/questioning.rb
+++ b/app/models/questioning.rb
@@ -62,6 +62,7 @@ class Questioning < FormItem
   delegate :group_name, to: :parent, prefix: true, allow_nil: true
 
   scope :visible, -> { where(hidden: false) }
+  scope :with_type_property, ->(property) { joins(:question).merge(Question.with_type_property(property)) }
 
   validates_with Forms::DynamicPatternValidator,
     field_name: :default,


### PR DESCRIPTION
Only allow filtering by reportable questions (e.g. don't show images, audio, etc. as refableQings for the question search filter).

~~@smoyth you mentioned something in the call today about using `ref`, but I didn't see how that worked here. I had already come up with this solution, so submitting for feedback. Let me know if you prefer something else.~~