### PR TITLE
9957 flapping reviewer notes spec

### DIFF
--- a/app/controllers/filter_data_controller.rb
+++ b/app/controllers/filter_data_controller.rb
@@ -12,6 +12,13 @@ class FilterDataController < ApplicationController
       .includes(:question).with_type_property(:refable).order("questions.code")
     qings = qings.where(form_id: params[:form_ids]) if params[:form_ids].present?
     qings = qings.filter_unique
+
+    # Temporary guard clause to investigate a strange flapping spec.
+    if (weird = qings.select { |qing| qing.full_rank.empty? }).any?
+      pp(weird)
+      raise "qing rank should always be non-empty"
+    end
+
     render(json: ActiveModel::ArraySerializer.new(qings,
       each_serializer: ConditionalLogicForm::TargetQuestioningSerializer))
   end

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -178,11 +178,13 @@ class FormItem < ApplicationRecord
 
   # Returns an array of ranks of all parents plus self, e.g. [2,5].
   # Uses the cached value setup by descendant_questionings if available.
+  # Returns empty array if this is the root node (i.e. path is [])
   def full_rank
     @full_rank ||= path.map(&:rank)[1..-1] || []
   end
 
   # Returns the full rank joined with a period separator, e.g. 2.5.
+  # Returns empty array if this is the root node (i.e. full_rank is [])
   def full_dotted_rank
     @full_dotted_rank ||= full_rank.join(".")
   end
@@ -201,7 +203,7 @@ class FormItem < ApplicationRecord
   def as_json(options = {})
     options[:methods] ||= []
     options[:methods] << :full_dotted_rank
-    result = super(options)
+    super(options)
   end
 
   def group_children?

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -179,7 +179,7 @@ class FormItem < ApplicationRecord
   # Returns an array of ranks of all parents plus self, e.g. [2,5].
   # Uses the cached value setup by descendant_questionings if available.
   def full_rank
-    @full_rank ||= path.map(&:rank)[1..-1]
+    @full_rank ||= path.map(&:rank)[1..-1] || []
   end
 
   # Returns the full rank joined with a period separator, e.g. 2.5.


### PR DESCRIPTION
Notes:
- Flapping started somewhere within https://github.com/thecartercenter/nemo/pull/617 (can't bisect precisely, not all commits compile, but somewhere in that range)
- The spec deterministically flaps **every other time it's run**, no matter what the seed value is

I'd prefer to do a more specific fix but I can't tell where `path` is actually getting set and it's too generic to search for. If you'd like to dive in feel free, but this fixes the flap and seems like a reasonably safe change.