### PR TITLE
9958: Stop preserving search query between missions

### DIFF
--- a/app/assets/javascripts/legacy/views/mission_change_dropdown.js
+++ b/app/assets/javascripts/legacy/views/mission_change_dropdown.js
@@ -15,8 +15,11 @@
         var path = ELMO.app.params.mode == 'basic' ? '' : window.location.pathname;
 
         // Preserve query string and add missionchange param to it.
-        var qs = window.location.search;
-        qs += (qs == '' ? '?' : '&') + 'missionchange=1';
+        var params = new URLSearchParams(window.location.search);
+        params.append('missionchange', '1');
+        // Remove the 'search' param for search filters.
+        params.delete('search');
+        var qs = '?' + params.toString();
 
         window.location.href = ELMO.app.url_builder.build(path, {mode: 'mission', mission_name: new_mission_name}) + qs;
       }


### PR DESCRIPTION
Uses [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) to build, modify, and stringify the url params without the `search` query.

Note: Normally I'd use the more conventional npm `query-string` lib for this but it seems like the legacy JS code wouldn't deal well with that. This should be a robust solution, as far as I know. Related SO question [here](https://stackoverflow.com/a/901144/763231) as well.