### PR TITLE
9775 filter integration specs

### DIFF
--- a/spec/features/search/question_search_spec.rb
+++ b/spec/features/search/question_search_spec.rb
@@ -10,7 +10,7 @@ feature "question search", js: true do
   let!(:question2) { create(:question, name: "How many pies?") }
   let!(:user) { create(:user, role_name: "coordinator", admin: true) }
 
-  scenario "search" do
+  scenario "search results" do
     login(user)
     visit "/en/m/#{mission.compact_name}/questions"
     expect(page).to have_content("Displaying all 2 Questions")
@@ -35,5 +35,16 @@ feature "question search", js: true do
     expect(page).to have_content(
       "Error: Your search query could not be understood due to unexpected text near the end."
     )
+  end
+
+  scenario "search filters" do
+    login(user)
+    visit "/en/m/#{mission.compact_name}/questions"
+
+    search_for(%(foo))
+    expect(page).to have_field("search", with: "foo")
+
+    # Filters UI shouldn't be active on this page.
+    expect(page).to_not(have_css("#form-filter"))
   end
 end

--- a/spec/features/search/question_search_spec.rb
+++ b/spec/features/search/question_search_spec.rb
@@ -45,6 +45,6 @@ feature "question search", js: true do
     expect(page).to have_field("search", with: "foo")
 
     # Filters UI shouldn't be active on this page.
-    expect(page).to_not(have_css("#form-filter"))
+    expect(page).not_to have_css("#form-filter")
   end
 end

--- a/spec/features/search/response_search_spec.rb
+++ b/spec/features/search/response_search_spec.rb
@@ -62,5 +62,17 @@ feature "response search", js: true do
     expect(page).to have_field("search", with: "")
     expect(page).to have_css("#submitter-filter.active-filter", text: "Submitter (2 filters)")
     expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (No)")
+
+    new_search_for(%(form:"Form 1"))
+    click_on("Question")
+    expect(page).to have_content("Showing questions from Form 1 only.")
+    click_on("Form (Form 1)")
+    # Clear the form filter.
+    find(".select2-selection__clear").click
+    # The hint should still be there until the search is submitted.
+    expect(page).to(have_css(".active-filter"))
+    # Click off to dismiss the popover and automatically submit the search.
+    find("h1").click
+    expect(page).to_not(have_css(".active-filter"))
   end
 end

--- a/spec/features/search/response_search_spec.rb
+++ b/spec/features/search/response_search_spec.rb
@@ -10,22 +10,20 @@ feature "response search", js: true do
   let!(:form) { create(:form, name: "Form 1", question_types: %w[text]) }
   let!(:response1) { create(:response, user: user, form: form, answer_values: ["foo"]) }
   let!(:response2) { create(:response, user: user, form: form, answer_values: ["bar"]) }
+  let(:codes) { Response.all.pluck(:shortcode).map(&:upcase) }
 
   scenario "search results" do
-    r1_code = response1.shortcode.upcase
-    r2_code = response2.shortcode.upcase
-
     login(user)
     visit "/en/m/#{mission.compact_name}/responses"
     expect(page).to have_content("Displaying all 2 Responses")
     expect(page).to have_content(form.name)
-    expect(page).to have_content(r1_code)
-    expect(page).to have_content(r2_code)
+    expect(page).to have_content(codes[0])
+    expect(page).to have_content(codes[1])
 
     # Working search.
     search_for("foo")
-    expect(page).to have_content(r1_code)
-    expect(page).not_to have_content(r2_code)
+    expect(page).to have_content(codes[0])
+    expect(page).not_to have_content(codes[1])
 
     # Failing search.
     search_for("bobby fisher")

--- a/spec/features/search/response_search_spec.rb
+++ b/spec/features/search/response_search_spec.rb
@@ -7,11 +7,12 @@ feature "response search", js: true do
 
   let!(:mission) { get_mission }
   let!(:user) { create(:user, role_name: "coordinator", admin: true) }
+  let(:user2) { create(:user) }
   let!(:form) { create(:form, name: "Form 1", question_types: %w[text]) }
   let!(:response1) { create(:response, user: user, form: form, answer_values: ["foo"]) }
   let!(:response2) { create(:response, user: user, form: form, answer_values: ["bar"]) }
 
-  scenario "search" do
+  scenario "search results" do
     r1_code = response1.shortcode.upcase
     r2_code = response2.shortcode.upcase
 
@@ -40,5 +41,26 @@ feature "response search", js: true do
     expect(page).to have_content(
       "Error: Your search query could not be understood due to unexpected text near the end."
     )
+  end
+
+  scenario "search filters" do
+    login(user)
+    visit "/en/m/#{mission.compact_name}/responses"
+
+    search_for(%(foo))
+    expect(page).to have_field("search", with: "foo")
+
+    new_search_for(%(form:"Form 1"))
+    expect(page).to have_field("search", with: "")
+    expect(page).to have_css("#form-filter.active-filter", text: "Form (Form 1)")
+
+    new_search_for(%(reviewed:YES))
+    expect(page).to have_field("search", with: "")
+    expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (Yes)")
+
+    new_search_for(%(submitter:("#{user.name}" | "#{user2.name}") reviewed:0))
+    expect(page).to have_field("search", with: "")
+    expect(page).to have_css("#submitter-filter.active-filter", text: "Submitter (2 filters)")
+    expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (No)")
   end
 end

--- a/spec/features/search/response_search_spec.rb
+++ b/spec/features/search/response_search_spec.rb
@@ -78,7 +78,7 @@ feature "response search", js: true do
       expect(page).to(have_css(".active-filter"))
       # Click off to dismiss the popover and automatically submit the search.
       find("h1").click
-      expect(page).to_not(have_css(".active-filter"))
+      expect(page).not_to have_css(".active-filter")
       expect(page).to have_content("Displaying all 3 Responses")
     end
   end

--- a/spec/features/search/response_search_spec.rb
+++ b/spec/features/search/response_search_spec.rb
@@ -66,6 +66,9 @@ feature "response search", js: true do
       expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (No)")
 
       new_search_for(%(form:"Form 1"))
+      expect(page).to have_content(codes[0])
+      expect(page).to have_content(codes[1])
+      expect(page).not_to have_content(codes[2])
       click_on("Question")
       expect(page).to have_content("Showing questions from Form 1 only.")
       click_on("Form (Form 1)")
@@ -76,6 +79,7 @@ feature "response search", js: true do
       # Click off to dismiss the popover and automatically submit the search.
       find("h1").click
       expect(page).to_not(have_css(".active-filter"))
+      expect(page).to have_content("Displaying all 3 Responses")
     end
   end
 end

--- a/spec/features/search/response_search_spec.rb
+++ b/spec/features/search/response_search_spec.rb
@@ -7,7 +7,6 @@ feature "response search", js: true do
 
   let!(:mission) { get_mission }
   let!(:user) { create(:user, role_name: "coordinator", admin: true) }
-  let(:user2) { create(:user) }
   let!(:form) { create(:form, name: "Form 1", question_types: %w[text]) }
   let!(:response1) { create(:response, user: user, form: form, answer_values: ["foo"]) }
   let!(:response2) { create(:response, user: user, form: form, answer_values: ["bar"]) }
@@ -43,36 +42,42 @@ feature "response search", js: true do
     )
   end
 
-  scenario "search filters" do
-    login(user)
-    visit "/en/m/#{mission.compact_name}/responses"
+  context "with more complex data" do
+    let!(:user2) { create(:user) }
+    let!(:form2) { create(:form, name: "Form 2", question_types: %w[text]) }
+    let!(:response3) { create(:response, user: user2, form: form2, answer_values: ["baz"]) }
 
-    search_for(%(foo))
-    expect(page).to have_field("search", with: "foo")
+    scenario "search filters" do
+      login(user)
+      visit "/en/m/#{mission.compact_name}/responses"
 
-    new_search_for(%(form:"Form 1"))
-    expect(page).to have_field("search", with: "")
-    expect(page).to have_css("#form-filter.active-filter", text: "Form (Form 1)")
+      search_for(%(foo))
+      expect(page).to have_field("search", with: "foo")
 
-    new_search_for(%(reviewed:YES))
-    expect(page).to have_field("search", with: "")
-    expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (Yes)")
+      new_search_for(%(form:"Form 1"))
+      expect(page).to have_field("search", with: "")
+      expect(page).to have_css("#form-filter.active-filter", text: "Form (Form 1)")
 
-    new_search_for(%(submitter:("#{user.name}" | "#{user2.name}") reviewed:0))
-    expect(page).to have_field("search", with: "")
-    expect(page).to have_css("#submitter-filter.active-filter", text: "Submitter (2 filters)")
-    expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (No)")
+      new_search_for(%(reviewed:YES))
+      expect(page).to have_field("search", with: "")
+      expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (Yes)")
 
-    new_search_for(%(form:"Form 1"))
-    click_on("Question")
-    expect(page).to have_content("Showing questions from Form 1 only.")
-    click_on("Form (Form 1)")
-    # Clear the form filter.
-    find(".select2-selection__clear").click
-    # The hint should still be there until the search is submitted.
-    expect(page).to(have_css(".active-filter"))
-    # Click off to dismiss the popover and automatically submit the search.
-    find("h1").click
-    expect(page).to_not(have_css(".active-filter"))
+      new_search_for(%(submitter:("#{user.name}" | "#{user2.name}") reviewed:0))
+      expect(page).to have_field("search", with: "")
+      expect(page).to have_css("#submitter-filter.active-filter", text: "Submitter (2 filters)")
+      expect(page).to have_css("#reviewed-filter.active-filter", text: "Reviewed (No)")
+
+      new_search_for(%(form:"Form 1"))
+      click_on("Question")
+      expect(page).to have_content("Showing questions from Form 1 only.")
+      click_on("Form (Form 1)")
+      # Clear the form filter.
+      find(".select2-selection__clear").click
+      # The hint should still be there until the search is submitted.
+      expect(page).to(have_css(".active-filter"))
+      # Click off to dismiss the popover and automatically submit the search.
+      find("h1").click
+      expect(page).to_not(have_css(".active-filter"))
+    end
   end
 end

--- a/spec/support/contexts/search.rb
+++ b/spec/support/contexts/search.rb
@@ -6,6 +6,12 @@ shared_context "search" do
     click_button("Search")
   end
 
+  def new_search_for(query)
+    # Clear the query params.
+    visit(current_path)
+    search_for(query)
+  end
+
   def expect_matches(matching, but_not: [])
     Array.wrap(matching).each { |m| expect(page).to have_content(m) }
     Array.wrap(but_not).each { |m| expect(page).not_to have_content(m) }


### PR DESCRIPTION
They've been a long time coming but they're finally here 🎊 

These integration tests confirm that:
- The filters are active on the responses page (but not the questions page)
- The filters parse search strings and display them using the UI
- The filters display hints
- The select2 fields can be cleared
- The filters submit automatically on dismiss popover

They're intended to be high-level and not comprehensive (e.g. there's no specific integration spec for choosing a question with the dropdowns since that's covered in more specific tests), but let me know if you think I should cover more cases or if I missed anything.