### PR TITLE
9987: Don't obstruct other header links with logo

### DIFF
--- a/app/assets/stylesheets/global/_layout.scss
+++ b/app/assets/stylesheets/global/_layout.scss
@@ -97,6 +97,9 @@ header {
   margin: side-values(10px 0 10px 15px);
   display: inline-block;
 
+  // Don't allow the large bounding box to obstruct other header links.
+  pointer-events: none;
+
   > div {
     display: inline-block;
     vertical-align: top;
@@ -107,6 +110,9 @@ header {
     margin: 12px 0 12px 12px;
     height: 54px;  /* explicit height to prevent shifting during load */
     vertical-align: bottom;
+
+    // Undo 'none' on the parent div.
+    pointer-events: all;
   }
 
   a {


### PR DESCRIPTION
Quick win I came across. On smaller screens the logo wraps down and covers up the operations link. Nothing within/underneath the highlighted box below is clickable:

<img width="727" alt="Screen Shot 2019-08-06 at 14 02 32" src="https://user-images.githubusercontent.com/2047062/62577254-6652a780-b853-11e9-8f33-049ccb97e403.png">
