### PR TITLE
9991 tabular import errors

### DIFF
--- a/app/jobs/tabular_import_operation_job.rb
+++ b/app/jobs/tabular_import_operation_job.rb
@@ -10,15 +10,15 @@ class TabularImportOperationJob < OperationJob
       file: open_file(saved_upload.file)
     )
     import.run
-    operation_failed(format_error_report(import.errors)) unless import.succeeded?
+    operation_failed(format_error_report(import.run_errors)) unless import.succeeded?
   end
 
   private
 
-  # turn the ActiveModel::Errors into a report in markdown format
+  # turn the import errors into a report in markdown format
   def format_error_report(errors)
     return if errors.empty?
-    errors.values.flatten.map { |error| "* #{error}" }.join("\n")
+    errors.map { |error| "* #{error}" }.join("\n")
   end
 
   def open_file(file)

--- a/spec/factories/saved_uploads.rb
+++ b/spec/factories/saved_uploads.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :saved_upload, class: SavedTabularUpload do
+    transient { filename nil }
+    file { user_import_fixture(filename) }
+  end
+end

--- a/spec/jobs/tabular_import_operation_job_spec.rb
+++ b/spec/jobs/tabular_import_operation_job_spec.rb
@@ -2,6 +2,8 @@
 
 require "rails_helper"
 
+# This spec just covers the handling of errors and etc. The specifics of which inputs cause which errors
+# should be handled in other specs specific to each import type.
 describe TabularImportOperationJob do
   let(:user) { create(:user, role_name: "coordinator") }
   let(:operation) { create(:operation, creator: user) }
@@ -12,8 +14,8 @@ describe TabularImportOperationJob do
 
     it "succeeds" do
       described_class.perform_now(operation, saved_upload_id: upload.id, import_class: "UserImport")
-      expect(operation.completed?).to be_truthy
-      expect(operation.failed?).to be_falsey
+      expect(operation.completed?).to be(true)
+      expect(operation.failed?).to be(false)
     end
   end
 
@@ -22,9 +24,10 @@ describe TabularImportOperationJob do
 
     it "handles errors gracefully" do
       described_class.perform_now(operation, saved_upload_id: upload.id, import_class: "UserImport")
-      expect(operation.completed?).to be_truthy
-      expect(operation.failed?).to be_truthy
-      expect(operation.job_error_report).to match("* Row 2: Main Phone: Please enter at least 9 digits.\n* Row 3: Username: Please use only unaccented letters, numbers, periods, and underscores.")
+      expect(operation.completed?).to be(true)
+      expect(operation.failed?).to be(true)
+      expect(operation.job_error_report).to match("* Row 2: Main Phone: Please enter at least 9 digits."\
+        "\n* Row 3: Username: Please use only unaccented letters, numbers, periods, and underscores.")
     end
   end
 end

--- a/spec/jobs/tabular_import_operation_job_spec.rb
+++ b/spec/jobs/tabular_import_operation_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe TabularImportOperationJob do
+  let(:user) { create(:user, role_name: "coordinator") }
+  let(:operation) { create(:operation, creator: user) }
+  let(:upload) { create(:saved_upload, filename: filename) }
+
+  context "with simple import" do
+    let(:filename) { "single_group.csv" }
+
+    it "succeeds" do
+      described_class.perform_now(operation, saved_upload_id: upload.id, import_class: "UserImport")
+      expect(operation.completed?).to be_truthy
+      expect(operation.failed?).to be_falsey
+    end
+  end
+
+  context "with simple validation error" do
+    let(:filename) { "errors.xlsx" }
+
+    it "handles errors gracefully" do
+      described_class.perform_now(operation, saved_upload_id: upload.id, import_class: "UserImport")
+      expect(operation.completed?).to be_truthy
+      expect(operation.failed?).to be_truthy
+      expect(operation.job_error_report).to match("* Row 2: Main Phone: Please enter at least 9 digits.\n* Row 3: Username: Please use only unaccented letters, numbers, periods, and underscores.")
+    end
+  end
+end


### PR DESCRIPTION
No error messages were being shown to the user for failed tabular import operations (at `/en/m/:mission/operations/:id`). Now they're back, e.g.

```
Error Report
Row 2: Main Phone: Please enter at least 9 digits.
Row 2: Alternate Phone: Please enter at least 9 digits.
```

Most recent related change seems to be https://github.com/thecartercenter/nemo/pull/583, for context -- specifically a change where `run_errors` were saved separately but not updated in this file.

New `tabular_import_operation_job_spec` was inspired by related `user_import_spec`.