### PR TITLE
#9899: Form "last modified" time should update when adding/modifying questions.

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -45,7 +45,7 @@ class Condition < ApplicationRecord
   # which is useful in tests and in UI consistency.
   acts_as_list column: :rank, scope: [:conditionable_id]
 
-  belongs_to :conditionable, polymorphic: true
+  belongs_to :conditionable, polymorphic: true, touch: true
   belongs_to :left_qing, class_name: "Questioning", foreign_key: "left_qing_id",
                          inverse_of: :referring_conditions_via_left
   belongs_to :right_qing, class_name: "Questioning", foreign_key: "right_qing_id",

--- a/app/models/form_item.rb
+++ b/app/models/form_item.rb
@@ -60,9 +60,9 @@ class FormItem < ApplicationRecord
 
   # These associations are really only applicable to Questioning, but
   # they are defined here to allow eager loading.
-  belongs_to :question, autosave: true, inverse_of: :questionings
+  belongs_to :question, autosave: true, inverse_of: :questionings, touch: true
 
-  belongs_to :form
+  belongs_to :form, touch: true, autosave: true
   has_many :response_nodes, foreign_key: :questioning_id, dependent: :destroy, inverse_of: :form_item
   has_many :standard_form_reports, class_name: "Report::StandardFormReport", inverse_of: :disagg_qing,
                                    foreign_key: :disagg_qing_id, dependent: :nullify
@@ -84,6 +84,7 @@ class FormItem < ApplicationRecord
   before_validation :set_foreign_key_on_conditions
   before_validation :ensure_parent_is_group
   before_create :inherit_mission
+  after_create :update_form
 
   has_ancestry cache_depth: true
 
@@ -283,6 +284,10 @@ class FormItem < ApplicationRecord
     errors.add(:display_logic, :all_required) if display_conditions.any?(&:invalid?)
     errors.add(:skip_logic, :all_required) if skip_rules.any?(&:invalid?)
     errors.add(:constraints, :all_required) if constraints.any?(&:invalid?)
+  end
+
+  def update_form
+    form.touch
   end
 end
 

--- a/app/models/form_logical.rb
+++ b/app/models/form_logical.rb
@@ -12,7 +12,7 @@ module FormLogical
     # which is useful in tests and in UI consistency.
     acts_as_list column: :rank, scope: [:source_item_id]
 
-    belongs_to :source_item, class_name: "FormItem", inverse_of: model_name.plural
+    belongs_to :source_item, class_name: "FormItem", inverse_of: model_name.plural, touch: true
     has_many :conditions, -> { by_rank }, as: :conditionable, inverse_of: :conditionable, dependent: :destroy
 
     before_validation :set_foreign_key_on_conditions

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -80,6 +80,7 @@ class Question < ApplicationRecord
 
   before_validation :normalize
   before_save :check_condition_integrity
+  after_save :update_forms
 
   # We do this instead of using dependent: :destroy because in the latter case
   # the dependent object doesn't know who destroyed it.
@@ -318,6 +319,10 @@ class Question < ApplicationRecord
 
   def check_condition_integrity
     Condition.check_integrity_after_question_change(self)
+  end
+
+  def update_forms
+    forms.each(&:touch)
   end
 
   def valid_reference_url

--- a/app/models/skip_rule.rb
+++ b/app/models/skip_rule.rb
@@ -32,7 +32,6 @@ class SkipRule < ActiveRecord::Base
   include FormLogical
 
   belongs_to :dest_item, class_name: "FormItem", inverse_of: :incoming_skip_rules
-  belongs_to :source_item, class_name: "FormItem"
 
   before_validation :normalize
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -230,6 +230,66 @@ describe Form do
     end
   end
 
+  describe "associations" do
+    let(:form) do
+      Timecop.freeze(-1.minute) do
+        create(:form, question_types: ["integer", %w[text text]])
+      end
+    end
+    let(:qing) { form.c[0] }
+    let(:qing_group) { form.c[1] }
+    let(:q) { form.c[0].question }
+    let(:updated_at) { form.updated_at }
+
+    it "updates form when a question is destroyed" do
+      q.destroy
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a question is updated" do
+      q.update!(maximum: 10)
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a qing group is destroyed" do
+      qing_group.destroy
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a qing group is updated" do
+      qing_group.update!(group_name: "New group name")
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when qing group is added" do
+      QingGroup.create!(form_id: form.id)
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a questioning is updated" do
+      qing.update!(rank: 10)
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a questioning is deleted" do
+      qing.destroy
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a questioning is added (covers adding a question)" do
+      Questioning.create!(form_id: form.id, question: create(:question))
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+  end
+
   def publish_and_reset_pub_changed_at(options = {})
     f = options[:form] || form
     f.publish!

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -277,6 +277,26 @@ describe Form do
       expect(updated_form.updated_at).not_to eq(updated_at)
     end
 
+    it "updates form when a display condition is added" do
+      form.c[1].c[0].update!(display_conditions_attributes:
+        [{left_qing_id: form.c[0].id, op: "eq", value: "5"}])
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a skip rule is added" do
+      qing.update!(skip_rules_attributes: [{destination: "end", skip_if: "always"}])
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
+    it "updates form when a constraint is added" do
+      qing.update!(constraints_attributes:
+        [{conditions_attributes: [{left_qing_id: qing.id, op: "eq", value: "5"}]}])
+      updated_form = Form.find(form.id)
+      expect(updated_form.updated_at).not_to eq(updated_at)
+    end
+
     it "updates form when a questioning is deleted" do
       qing.destroy
       updated_form = Form.find(form.id)


### PR DESCRIPTION
Added `touch: true` and callbacks to ensure creating, updating and deleting QingGroups, Questionings and Questions updated the `updated_at` timestamp on related forms.