### PR TITLE
9766 - Only email active users on SMS token change.

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -29,11 +29,11 @@ class Notifier < ApplicationMailer
 
   def coordinator_emails(mission)
     return [] if mission.nil?
-    User.with_roles(mission, :coordinator).pluck(:email).uniq[0, 10] # Max of 10, should be rare.
+    User.with_roles(mission, :coordinator).active.pluck(:email).uniq[0, 10] # Max of 10, should be rare.
   end
 
   def admin_emails
-    User.where(admin: true).pluck(:email)
+    User.where(admin: true).active.pluck(:email)
   end
 
   def build_reset_url(user)

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -10,7 +10,7 @@ describe Notifier do
     let(:mail) { described_class.password_reset_instructions(*args).deliver_now }
 
     it "should have user's email in to field" do
-      expect(mail.to).to eq [user.email]
+      expect(mail.to).to eq([user.email])
     end
 
     context "no mission given" do
@@ -58,10 +58,10 @@ describe Notifier do
     end
 
     context "mission has inactive admins and coordinators" do
-      let!(:coordinator1) { create(:user, role_name: :coordinator, mission: mission, active: false)}
-      let!(:coordinator2) { create(:user, role_name: :coordinator, mission: mission)}
-      let!(:admin1) { create(:user, role_name: :staffer, mission: mission, admin: true, active: false)}
-      let!(:admin2) { create(:user, role_name: :staffer, mission: mission, admin: true)}
+      let!(:coordinator1) { create(:user, role_name: :coordinator, mission: mission, active: false) }
+      let!(:coordinator2) { create(:user, role_name: :coordinator, mission: mission) }
+      let!(:admin1) { create(:user, role_name: :staffer, mission: mission, admin: true, active: false) }
+      let!(:admin2) { create(:user, role_name: :staffer, mission: mission, admin: true) }
 
       it "should only email active users" do
         expect(mail.to).to contain_exactly(coordinator2.email, admin2.email)

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -56,5 +56,17 @@ describe Notifier do
         expect(mail.reply_to).to contain_exactly(coordinator1.email, coordinator2.email, staffer2.email)
       end
     end
+
+    context "mission has inactive admins and coordinators" do
+      let!(:coordinator1) { create(:user, role_name: :coordinator, mission: mission, active: false)}
+      let!(:coordinator2) { create(:user, role_name: :coordinator, mission: mission)}
+      let!(:admin1) { create(:user, role_name: :staffer, mission: mission, admin: true, active: false)}
+      let!(:admin2) { create(:user, role_name: :staffer, mission: mission, admin: true)}
+
+      it "should only email active users" do
+        expect(mail.to).to contain_exactly(coordinator2.email, admin2.email)
+        expect(mail.reply_to).to contain_exactly(coordinator2.email, admin2.email)
+      end
+    end
   end
 end


### PR DESCRIPTION
Only send emails to active users or admins when an SMS token is changed for a mission.