### PR TITLE
10222: Removing `elmo-` from response CSV export filename.

### DIFF
--- a/app/jobs/response_csv_export_operation_job.rb
+++ b/app/jobs/response_csv_export_operation_job.rb
@@ -28,7 +28,7 @@ class ResponseCsvExportOperationJob < OperationJob
   def generate_csv(responses)
     attachment = Results::Csv::Generator.new(responses).export
     timestamp = Time.current.to_s(:filename_datetime)
-    attachment_download_name = "elmo-#{mission.compact_name}-responses-#{timestamp}.csv"
+    attachment_download_name = "#{mission.compact_name}-responses-#{timestamp}.csv"
     {attachment: attachment, attachment_download_name: attachment_download_name}
   end
 end


### PR DESCRIPTION
Removing ELMO from filename for response CSV exports. This may need to happen for option sets as well, but it isn't clear if/where that is happening.