### PR TITLE
9010: Add test to ensure SMS test send button is not disabled after use.

### DIFF
--- a/app/views/sms_tests/new.html.erb
+++ b/app/views/sms_tests/new.html.erb
@@ -7,7 +7,7 @@
   <%= f.field(:body, :type => :textarea) %>
 
   <div class="submit-buttons">
-    <%= f.submit(:send, class: "btn btn-primary") %>
+    <%= f.submit(:send, class: "btn btn-primary", data: { disable_with: false }) %>
   </div>
 
   <div class="sms_test_result">

--- a/spec/features/sms/sms_console_spec.rb
+++ b/spec/features/sms/sms_console_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "SMS Console", js: true do
+  let!(:user) { create(:user) }
+  let!(:mission_name) { get_mission.compact_name }
+  let(:form) { create(:form, question_types: %w[integer], smsable: true).tap(&:publish!) }
+
+  before do
+    login(user)
+  end
+
+  scenario "testing SMS console" do
+    visit(new_sms_test_path(mode: "m", mission_name: mission_name, locale: "en"))
+    fill_in("From", with: user.phone)
+    fill_in("Body", with: "#{form.code} 1.123")
+    click_button("Send")
+
+    expect(page).to have_content("Your response to form")
+    expect(page).to have_button("Send", disabled: false)
+  end
+end

--- a/spec/requests/sms/sms_console_spec.rb
+++ b/spec/requests/sms/sms_console_spec.rb
@@ -9,19 +9,6 @@ describe "sms console", :sms do
     login(user)
   end
 
-  context "with integer form" do
-    let(:qtypes) { %w(integer) }
-
-    it "going to the page to create a new sms should succeed" do
-      get_s("/en/m/#{mission_name}/sms-tests/new")
-    end
-
-    it "submitting a test sms should succeed" do
-      post("/en/m/#{mission_name}/sms-tests", params: {sms_test: {from: user.phone, body: "#{form.code} 1.123"}})
-      expect(response.body).to match /\AYour response to form '.+' was received. Thank you!\z/
-    end
-  end
-
   context "with datetime form" do
     let(:qtypes) { %w(datetime) }
 


### PR DESCRIPTION
Added test to ensure SMS test console send button is not disabled after use. Modified view to not disable after use instead of re-enabling after the fact.