### PR TITLE
10173 filter ui abilities

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -113,6 +113,9 @@ class Ability
   end
 
   def mission_dependent_permissions
+    can(%i[possible_submitters possible_reviewers], Response, mission_id: mission.id)
+    can(%i[index possible_groups], UserGroup, mission_id: mission.id)
+
     enumerator_permissions if user_has_this_or_higher_role_in_mission?(:enumerator)
     reviewer_permissions if user_has_this_or_higher_role_in_mission?(:reviewer)
     staffer_permissions if user_has_this_or_higher_role_in_mission?(:staffer)

--- a/spec/models/ability/form_ability_spec.rb
+++ b/spec/models/ability/form_ability_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for abilities related to Form object.
 require "rails_helper"
 
@@ -10,12 +12,12 @@ describe "abilities for forms" do
 
     context "when standard" do
       before do
-        @form = create(:form, :standard, question_types: %w(text))
+        @form = create(:form, :standard, question_types: %w[text])
       end
 
       it "should have limited abilities" do
-        %i(show clone update add_questions remove_questions reorder_questions destroy).each { |op| expect(@ability).to be_able_to(op, @form) }
-        %i(publish).each { |op| expect(@ability).not_to be_able_to(op, @form) }
+        %i[show clone update add_questions remove_questions reorder_questions destroy].each { |op| expect(@ability).to be_able_to(op, @form) }
+        %i[publish].each { |op| expect(@ability).not_to be_able_to(op, @form) }
       end
     end
   end
@@ -27,17 +29,17 @@ describe "abilities for forms" do
     end
 
     it "should be able to create and index" do
-      %i(create index).each { |op| expect(@ability).to be_able_to(op, Form) }
+      %i[create index].each { |op| expect(@ability).to be_able_to(op, Form) }
     end
 
     context "when unpublished" do
       before do
-        @form = create(:form, question_types: %w(text))
+        @form = create(:form, question_types: %w[text])
       end
 
       it "should be able to do all except download" do
-        %i(show update publish clone add_questions remove_questions reorder_questions destroy).each { |op| expect(@ability).to be_able_to(op, @form) }
-        %i(download).each { |op| expect(@ability).not_to be_able_to(op, @form) }
+        %i[show update publish clone add_questions remove_questions reorder_questions destroy].each { |op| expect(@ability).to be_able_to(op, @form) }
+        %i[download].each { |op| expect(@ability).not_to be_able_to(op, @form) }
       end
 
       context "with responses" do
@@ -47,43 +49,43 @@ describe "abilities for forms" do
         end
 
         it "should be able to do all but destroy" do
-          %i(show update publish clone add_questions remove_questions reorder_questions).each { |op| expect(@ability).to be_able_to(op, @form) }
-          %i(download destroy).each { |op| expect(@ability).not_to be_able_to(op, @form) }
+          %i[show update publish clone add_questions remove_questions reorder_questions].each { |op| expect(@ability).to be_able_to(op, @form) }
+          %i[download destroy].each { |op| expect(@ability).not_to be_able_to(op, @form) }
         end
       end
     end
 
     context "when published" do
       before do
-        @form = create(:form, question_types: %w(text))
+        @form = create(:form, question_types: %w[text])
         @form.publish!
       end
 
       it "should have limited abilities" do
-        %i(show update publish download clone).each { |op| expect(@ability).to be_able_to(op, @form) }
-        %i(add_questions remove_questions reorder_questions destroy).each { |op| expect(@ability).not_to be_able_to(op, @form) }
+        %i[show update publish download clone].each { |op| expect(@ability).to be_able_to(op, @form) }
+        %i[add_questions remove_questions reorder_questions destroy].each { |op| expect(@ability).not_to be_able_to(op, @form) }
       end
     end
 
     context "when standard" do
       before do
-        @form = create(:form, :standard, question_types: %w(text))
+        @form = create(:form, :standard, question_types: %w[text])
       end
 
       it "should be able to do nothing" do
-        %i(show update add_questions remove_questions reorder_questions destroy download publish clone).each { |op| expect(@ability).not_to be_able_to(op, @form) }
+        %i[show update add_questions remove_questions reorder_questions destroy download publish clone].each { |op| expect(@ability).not_to be_able_to(op, @form) }
       end
     end
 
     context "when unpublished std copy" do
       before do
-        @std = create(:form, :standard, question_types: %w(text))
+        @std = create(:form, :standard, question_types: %w[text])
         @copy = @std.replicate(mode: :to_mission, dest_mission: get_mission)
       end
 
       it "should have same abilities as unlinked unpublished form" do
-        %i(show update publish clone add_questions remove_questions reorder_questions destroy).each { |op| expect(@ability).to be_able_to(op, @copy) }
-        %i(download).each { |op| expect(@ability).not_to be_able_to(op, @copy) }
+        %i[show update publish clone add_questions remove_questions reorder_questions destroy].each { |op| expect(@ability).to be_able_to(op, @copy) }
+        %i[download].each { |op| expect(@ability).not_to be_able_to(op, @copy) }
       end
     end
   end

--- a/spec/models/ability/question_ability_spec.rb
+++ b/spec/models/ability/question_ability_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for abilities related to Question object.
 require "rails_helper"
 
@@ -9,17 +11,17 @@ describe "abilities for questions" do
     end
 
     it "should be able to create and index" do
-      %i(create index).each { |op| expect(@ability).to be_able_to(op, Question) }
+      %i[create index].each { |op| expect(@ability).to be_able_to(op, Question) }
     end
 
     context "when unpublished" do
       before do
-        @form = create(:form, question_types: %w(text))
+        @form = create(:form, question_types: %w[text])
         @question = @form.questions.first
       end
 
       it "should be able to do all" do
-        %i(show update update_code update_core destroy).each { |op| expect(@ability).to be_able_to(op, @question) }
+        %i[show update update_code update_core destroy].each { |op| expect(@ability).to be_able_to(op, @question) }
       end
 
       context "with answers" do
@@ -28,35 +30,35 @@ describe "abilities for questions" do
         end
 
         it "should be able to do all but destroy and update core" do
-          %i(show update update_code).each { |op| expect(@ability).to be_able_to(op, @question) }
-          %i(update_core destroy).each { |op| expect(@ability).not_to be_able_to(op, @question) }
+          %i[show update update_code].each { |op| expect(@ability).to be_able_to(op, @question) }
+          %i[update_core destroy].each { |op| expect(@ability).not_to be_able_to(op, @question) }
         end
       end
     end
 
     context "when published" do
       before do
-        @form = create(:form, question_types: %w(text))
+        @form = create(:form, question_types: %w[text])
         @form.publish!
         @question = @form.questions.first
       end
 
       it "should be able show and update only" do
-        %i(show update update_code).each { |op| expect(@ability).to be_able_to(op, @question) }
-        %i(update_core destroy).each { |op| expect(@ability).not_to be_able_to(op, @question) }
+        %i[show update update_code].each { |op| expect(@ability).to be_able_to(op, @question) }
+        %i[update_core destroy].each { |op| expect(@ability).not_to be_able_to(op, @question) }
       end
     end
 
     context "when unpublished std copy" do
       before do
-        @std = create(:form, :standard, question_types: %w(text))
+        @std = create(:form, :standard, question_types: %w[text])
         @copy = @std.replicate(mode: :to_mission, dest_mission: get_mission)
         @question = @copy.questions.first
       end
 
       it "should be able to do all except update_code" do
-        %i(show update update_core destroy).each { |op| expect(@ability).to be_able_to(op, @question) }
-        %i(update_code).each { |op| expect(@ability).not_to be_able_to(op, @question) }
+        %i[show update update_core destroy].each { |op| expect(@ability).to be_able_to(op, @question) }
+        %i[update_code].each { |op| expect(@ability).not_to be_able_to(op, @question) }
       end
     end
   end

--- a/spec/models/ability/questioning_ability_spec.rb
+++ b/spec/models/ability/questioning_ability_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Tests for abilities related to Questioning object.
 require "rails_helper"
 
@@ -11,11 +13,11 @@ describe "abilities for questionings" do
     end
 
     context "when unpublished" do
-      let(:form) { create(:form, question_types: %w(text)) }
+      let(:form) { create(:form, question_types: %w[text]) }
       let(:qing) { form.questionings.first }
 
       it "should be able to do all" do
-        %i(show update update_core destroy).each do |op|
+        %i[show update update_core destroy].each do |op|
           expect(ability).to be_able_to(op, qing)
         end
       end
@@ -24,10 +26,10 @@ describe "abilities for questionings" do
         let!(:response) { create(:response, form: form, answer_values: ["foo"]) }
 
         it "should be able to do all but destroy" do
-          %i(show update update_core).each do |op|
+          %i[show update update_core].each do |op|
             expect(ability).to be_able_to(op, qing)
           end
-          %i(destroy).each do |op|
+          %i[destroy].each do |op|
             expect(ability).not_to be_able_to(op, qing)
           end
         end
@@ -35,26 +37,26 @@ describe "abilities for questionings" do
     end
 
     context "when published" do
-      let(:form) { create(:form, :published, question_types: %w(text)) }
+      let(:form) { create(:form, :published, question_types: %w[text]) }
       let(:qing) { form.questionings.first }
 
       it "should be able show and update only" do
-        %i(show update).each do |op|
+        %i[show update].each do |op|
           expect(ability).to be_able_to(op, qing)
         end
-        %i(update_core destroy).each do |op|
+        %i[update_core destroy].each do |op|
           expect(ability).not_to be_able_to(op.to_sym, qing)
         end
       end
     end
 
     context "when unpublished std copy" do
-      let(:std) { create(:form, :standard, question_types: %w(text)) }
+      let(:std) { create(:form, :standard, question_types: %w[text]) }
       let(:copy) { std.replicate(mode: :to_mission, dest_mission: get_mission) }
       let(:qing) { copy.questionings.first }
 
       it "should be able to do all" do
-        %i(show update update_core destroy).each do |op|
+        %i[show update update_core destroy].each do |op|
           expect(ability).to be_able_to(op, qing)
         end
       end

--- a/spec/models/ability/response_ability_spec.rb
+++ b/spec/models/ability/response_ability_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe Response do
@@ -9,7 +11,7 @@ describe Response do
 
   let(:form) do
     FactoryGirl.create(:form,
-      name: "SMS Form", smsable: true, mission: get_mission, question_types: %w(integer text))
+      name: "SMS Form", smsable: true, mission: get_mission, question_types: %w[integer text])
   end
   let(:form_answers) { [1, "Lorem ipsum try me again"] }
   let(:response) { create(:response, form: form, answer_values: form_answers) }
@@ -17,16 +19,16 @@ describe Response do
 
   context "as an enumerator" do
     it "should be able to create a response" do
-      expect(ability).to be_able_to :create, own_response
+      expect(ability).to be_able_to(:create, own_response)
     end
 
     it "should be able to edit own response" do
-      expect(ability).to be_able_to :edit, own_response
+      expect(ability).to be_able_to(:edit, own_response)
     end
 
     it "should not be able to see, modify, or delete the responses of others" do
-      %w(index show new create edit update destroy delete review export).each do |action|
-        expect(ability).to_not be_able_to action.to_sym, response
+      %w[index show new create edit update destroy delete review export].each do |action|
+        expect(ability).to_not(be_able_to(action.to_sym, response))
       end
     end
   end
@@ -35,28 +37,28 @@ describe Response do
     let(:user) { create(:user, role_name: "reviewer") }
 
     it "should be able to create a response" do
-      expect(ability).to be_able_to :create, own_response
+      expect(ability).to be_able_to(:create, own_response)
     end
 
     it "should be able to edit own response" do
-      expect(ability).to be_able_to :edit, own_response
-      expect(ability).to be_able_to :modify_answers, own_response
-      expect(ability).to be_able_to :update, own_response
-      expect(ability).to be_able_to :destroy, own_response
+      expect(ability).to be_able_to(:edit, own_response)
+      expect(ability).to be_able_to(:modify_answers, own_response)
+      expect(ability).to be_able_to(:update, own_response)
+      expect(ability).to be_able_to(:destroy, own_response)
     end
 
     it "should be able to view others responses" do
-      expect(ability).to be_able_to :index, response
-      expect(ability).to be_able_to :show, response
+      expect(ability).to be_able_to(:index, response)
+      expect(ability).to be_able_to(:show, response)
     end
 
     it "should be able to review others responses" do
-      expect(ability).to be_able_to :review, response
+      expect(ability).to be_able_to(:review, response)
     end
 
     it "should not be able to edit or otherwise modify others responses" do
-      %w(modify destroy delete export).each do |action|
-        expect(ability).to_not be_able_to action.to_sym, response
+      %w[modify destroy delete export].each do |action|
+        expect(ability).to_not(be_able_to(action.to_sym, response))
       end
     end
   end

--- a/spec/models/ability/user_group_ability_spec.rb
+++ b/spec/models/ability/user_group_ability_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Tests for abilities related to UserGroup object.
+require "rails_helper"
+
+describe "abilities for user_groups" do
+  context "for coordinator role" do
+    let(:user) { create(:user, role_name: "coordinator") }
+    let(:ability) { Ability.new(user: user, mode: "mission", mission: get_mission) }
+
+    it "should be able to create" do
+      expect(ability).to be_able_to(:create, UserGroup)
+      expect(ability).to be_able_to(:create, UserGroupAssignment)
+    end
+  end
+
+  context "for enumerator role" do
+    let(:user) { create(:user, role_name: "enumerator") }
+    let(:ability) { Ability.new(user: user, mode: "mission", mission: get_mission) }
+
+    it "should not be able to create" do
+      expect(ability).not_to be_able_to(:create, UserGroup)
+      expect(ability).not_to be_able_to(:create, UserGroupAssignment)
+    end
+  end
+end

--- a/spec/models/ability/user_group_ability_spec.rb
+++ b/spec/models/ability/user_group_ability_spec.rb
@@ -12,6 +12,10 @@ describe "abilities for user_groups" do
       expect(ability).to be_able_to(:create, UserGroup)
       expect(ability).to be_able_to(:create, UserGroupAssignment)
     end
+
+    it "should be able to possible_groups" do
+      expect(ability).to be_able_to(:possible_groups, UserGroup)
+    end
   end
 
   context "for enumerator role" do
@@ -21,6 +25,10 @@ describe "abilities for user_groups" do
     it "should not be able to create" do
       expect(ability).not_to be_able_to(:create, UserGroup)
       expect(ability).not_to be_able_to(:create, UserGroupAssignment)
+    end
+
+    it "should be able to possible_groups" do
+      expect(ability).to be_able_to(:possible_groups, UserGroup)
     end
   end
 end


### PR DESCRIPTION
As-is, this change allows ALL users to use the new filters UI. The reported issue mentioned staffers not being able to view groups, but the bug also affected all non-coordinators and also applied to the user dropdown.

If this is too permissive or you'd like additional test coverage, let's chat.