### PR TITLE
10225: Fix nil rejection_msg_translations issue

### DIFF
--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -8,7 +8,7 @@
 #  id                         :uuid             not null, primary key
 #  accept_if                  :string(16)       default("all_met"), not null
 #  rank                       :integer          not null
-#  rejection_msg_translations :jsonb            not null
+#  rejection_msg_translations :jsonb
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  mission_id                 :uuid

--- a/db/migrate/20191009175040_remove_null_rejection_msg_constraint.rb
+++ b/db/migrate/20191009175040_remove_null_rejection_msg_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNullRejectionMsgConstraint < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :constraints, :rejection_msg_translations, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_17_185223) do
+ActiveRecord::Schema.define(version: 2019_10_09_175040) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -126,7 +126,7 @@ ActiveRecord::Schema.define(version: 2019_09_17_185223) do
     t.datetime "created_at", null: false
     t.uuid "mission_id"
     t.integer "rank", null: false
-    t.jsonb "rejection_msg_translations", default: {}, null: false
+    t.jsonb "rejection_msg_translations", default: {}
     t.uuid "source_item_id", null: false
     t.datetime "updated_at", null: false
     t.index ["mission_id"], name: "index_constraints_on_mission_id"

--- a/spec/factories/constraints.rb
+++ b/spec/factories/constraints.rb
@@ -8,7 +8,7 @@
 #  id                         :uuid             not null, primary key
 #  accept_if                  :string(16)       default("all_met"), not null
 #  rank                       :integer          not null
-#  rejection_msg_translations :jsonb            not null
+#  rejection_msg_translations :jsonb
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  mission_id                 :uuid

--- a/spec/models/constraint_spec.rb
+++ b/spec/models/constraint_spec.rb
@@ -8,7 +8,7 @@
 #  id                         :uuid             not null, primary key
 #  accept_if                  :string(16)       default("all_met"), not null
 #  rank                       :integer          not null
-#  rejection_msg_translations :jsonb            not null
+#  rejection_msg_translations :jsonb
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
 #  mission_id                 :uuid


### PR DESCRIPTION
rejection_msg_translations already had a default, but was being set to `nil` due to empty strings for every locale.