### PR TITLE
[discuss later] Update selenium-webdriver for Chrome 76+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,8 +144,7 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
+    childprocess (3.0.0)
     choice (0.2.0)
     chronic (0.10.2)
     chunky_png (1.3.11)
@@ -234,7 +233,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
-    ffi (1.10.0)
+    ffi (1.11.1)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -471,7 +470,7 @@ GEM
       sexp_processor (~> 4.6)
     ruby_parser (3.12.0)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -496,9 +495,9 @@ GEM
       ffi-compiler (>= 1.0, < 2.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    selenium-webdriver (3.141.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.2, >= 1.2.2)
+    selenium-webdriver (3.142.6)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sexp_processor (4.11.0)
     slop (3.6.0)
     spinjs-rails (1.3)
@@ -662,4 +661,4 @@ DEPENDENCIES
   will_paginate-bootstrap4 (~> 0.2.2)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -28,11 +28,11 @@ Note to install the software below we recommend the following package managers:
 1. ImageMagick 6.7+
     - ImageMagick is used to resize uploaded images.
     - It should be available through any of the package managers listed above. If not it can be built from source.
-1. Chrome (Browser) 60+
+1. Chrome (Browser) 76+
     - Used for automated browser testing.
-1. Chromedriver 2.35+
+1. Chromedriver 76+
     - Handles running Chrome headlessly for feature specs.
-    - It should be available through any of the package managers listed above. If not it can be built from source.
+    - It should be available through any of the package managers listed above, or [here](https://sites.google.com/a/chromium.org/chromedriver/downloads). If not it can be built from source.
     - The Rails Gem that talks to Chromedriver is called `selenium-webdriver`.
 1. GraphViz 2.36+
     - [GraphViz](http://graphviz.org/) is used to visualize the relationships between data in the database.


### PR DESCRIPTION
Otherwise some tests don't run locally for me.

I'm on Chrome 78, and my old version of chromedriver only supported through 75; after updating my local chromedriver it required updating selenium-webdriver to support the w3c `log` method.

- Changelog [here](https://github.com/SeleniumHQ/selenium/blob/master/rb/CHANGES) that mentions w3c `log`
- Alternative workaround suggested [here](https://github.com/SeleniumHQ/selenium/issues/7270#issuecomment-500317620) with `w3c: false`.

CI probably also needs updated config, or maybe there's a better solution I missed. Too busy this week to diagnose further but let's chat later.