### PR TITLE
10267 fix group condition issue [hotfix]

### DIFF
--- a/app/javascript/components/Filters/injector.js
+++ b/app/javascript/components/Filters/injector.js
@@ -7,6 +7,8 @@ import { provideFiltersStore } from './utils';
 import { submitterType } from './SubmitterFilter/utils';
 import Filters from './component';
 
+let forcedResetNonce = 0;
+
 /**
  * Provides any needed stores to its children.
  */
@@ -38,8 +40,9 @@ function Injector(props) {
   });
   const { conditionSetStore } = filtersStore;
 
+  // eslint-disable-next-line no-return-assign
   return (
-    <Provider filtersStore={filtersStore} conditionSetStore={conditionSetStore}>
+    <Provider key={forcedResetNonce += 1} filtersStore={filtersStore} conditionSetStore={conditionSetStore}>
       <Filters {...props} />
     </Provider>
   );

--- a/app/javascript/components/Filters/utils.js
+++ b/app/javascript/components/Filters/utils.js
@@ -13,25 +13,20 @@ export const CONTROLLER_NAME = {
   RESPONSES: '"responses"',
 };
 
-/** Cache. */
-let filtersStore = null;
-
 /**
  * Returns a new instance of FiltersModel.
  *
  * Generally this should be added to a top-level Provider and only used once.
  */
 export function provideFiltersStore(FiltersModel, initialState) {
-  if (!filtersStore) {
-    filtersStore = new FiltersModel(initialState);
+  const store = new FiltersModel(initialState);
 
-    if (process.env.NODE_ENV === 'development') {
-      // Debug helper.
-      window.store = filtersStore;
-    }
+  if (process.env.NODE_ENV === 'development') {
+    // Debug helper.
+    window.store = store;
   }
 
-  return filtersStore;
+  return store;
 }
 
 /**

--- a/app/javascript/components/conditions/ConditionSetFormField/utils.js
+++ b/app/javascript/components/conditions/ConditionSetFormField/utils.js
@@ -1,6 +1,3 @@
-/** Cache. */
-const conditionSetStores = {};
-
 /**
  * Returns a new instance of ConditionSetModel.
  *
@@ -8,17 +5,15 @@ const conditionSetStores = {};
  * once per condition set.
  */
 export function provideConditionSetStore(ConditionSetModel, uniqueId, initialState) {
-  if (!conditionSetStores[uniqueId]) {
-    conditionSetStores[uniqueId] = new ConditionSetModel(initialState);
+  const store = new ConditionSetModel(initialState);
 
-    if (process.env.NODE_ENV === 'development') {
-      // Debug helper.
-      window.store = window.store || {};
-      window.store[uniqueId] = conditionSetStores[uniqueId];
-    }
+  if (process.env.NODE_ENV === 'development') {
+    // Debug helper.
+    window.store = window.store || {};
+    window.store[uniqueId] = store;
   }
 
-  return conditionSetStores[uniqueId];
+  return store;
 }
 
 /**

--- a/app/javascript/components/conditions/ConstraintsFormField/ConstraintFormField/injector.js
+++ b/app/javascript/components/conditions/ConstraintsFormField/ConstraintFormField/injector.js
@@ -6,6 +6,8 @@ import ConditionSetModel from '../../ConditionSetFormField/model';
 import { provideConditionSetStore } from '../../ConditionSetFormField/utils';
 import ConstraintFormField from './component';
 
+let forcedResetNonce = 0;
+
 /**
  * Provides any needed stores to its children.
  */
@@ -29,8 +31,9 @@ function Injector(props) {
     rejectionMsgTranslations: rejectionMsgTranslations || {},
   });
 
+  // eslint-disable-next-line no-return-assign
   return (
-    <Provider conditionSetStore={conditionSetStore}>
+    <Provider key={forcedResetNonce += 1} conditionSetStore={conditionSetStore}>
       <ConstraintFormField {...props} />
     </Provider>
   );

--- a/app/javascript/components/conditions/DisplayLogicFormField/injector.js
+++ b/app/javascript/components/conditions/DisplayLogicFormField/injector.js
@@ -6,6 +6,8 @@ import ConditionSetModel from '../ConditionSetFormField/model';
 import { provideConditionSetStore } from '../ConditionSetFormField/utils';
 import DisplayLogicFormField from './component';
 
+let forcedResetNonce = 0;
+
 /**
  * Provides any needed stores to its children.
  */
@@ -30,8 +32,9 @@ function Injector(props) {
     hide: displayIf === 'always',
   });
 
+  // eslint-disable-next-line no-return-assign
   return (
-    <Provider conditionSetStore={conditionSetStore}>
+    <Provider key={forcedResetNonce += 1} conditionSetStore={conditionSetStore}>
       <DisplayLogicFormField {...props} />
     </Provider>
   );

--- a/app/javascript/components/conditions/SkipLogicFormField/SkipRuleFormField/injector.js
+++ b/app/javascript/components/conditions/SkipLogicFormField/SkipRuleFormField/injector.js
@@ -6,6 +6,8 @@ import ConditionSetModel from '../../ConditionSetFormField/model';
 import { provideConditionSetStore } from '../../ConditionSetFormField/utils';
 import SkipRuleFormField from './component';
 
+let forcedResetNonce = 0;
+
 /**
  * Provides any needed stores to its children.
  */
@@ -31,8 +33,9 @@ function Injector(props) {
     hide: skipIf === 'always',
   });
 
+  // eslint-disable-next-line no-return-assign
   return (
-    <Provider conditionSetStore={conditionSetStore}>
+    <Provider key={forcedResetNonce += 1} conditionSetStore={conditionSetStore}>
       <SkipRuleFormField {...props} />
     </Provider>
   );

--- a/spec/features/forms/form/item_edit_spec.rb
+++ b/spec/features/forms/form/item_edit_spec.rb
@@ -41,7 +41,7 @@ feature "forms", js: true do
       end
 
       # Edit a group
-      form_item([3, 0]).find(".fa-pencil").click
+      click_form_item_action_icon([3, 0], :edit)
       expect(page).to have_css(".modal-title", text: "Edit Group")
       fill_in("Name (English)", with: "Inner Groupe")
       find(".modal-footer .btn-primary").click
@@ -81,13 +81,13 @@ feature "forms", js: true do
 
     scenario "deleting elements" do
       visit(edit_url)
-      form_item([1, 0]).find(".fa-trash-o").click
+      click_form_item_action_icon([1, 0], :delete)
       message = accept_confirm
       expect(message).to match("question '#{q10_name}'")
       wait_for_ajax # Need to wait or we get down into bottom part of the test before ajax completes.
       expect(page).not_to have_content(q10_name)
 
-      form_item([1]).find(".fa-trash-o").click
+      click_form_item_action_icon([1], :delete)
       message = accept_confirm
       expect(message).to match("group '#{g1_name}'")
       wait_for_ajax
@@ -144,7 +144,7 @@ feature "forms", js: true do
     within(".modal") { click_button("Save") }
   end
 
-  def form_item_selector(path)
+  def form_item_selector(path, inner: false)
     selector = [".draggable-list-wrapper"]
 
     path.each do |index|
@@ -153,11 +153,19 @@ feature "forms", js: true do
       selector << "> li.form-item:nth-child(#{index + 1})"
     end
 
-    selector.join(" ")
+    selector.join(" ") << (inner ? "> div.inner" : "")
   end
 
-  def form_item(path)
-    find(form_item_selector(path))
+  def form_item(path, inner: false)
+    find(form_item_selector(path, inner: inner))
+  end
+
+  def click_form_item_action_icon(path, action)
+    icon_class = case action
+                 when :delete then "fa-trash-o"
+                 when :edit then "fa-pencil"
+                 end
+    form_item(path, inner: true).find(".#{icon_class}").click
   end
 
   def release_item

--- a/spec/features/forms/form/item_edit_spec.rb
+++ b/spec/features/forms/form/item_edit_spec.rb
@@ -137,6 +137,52 @@ feature "forms", js: true do
     end
   end
 
+  context "with groups and conditions" do
+    let(:question_types) { ["integer", %w[integer], %w[integer]] }
+
+    before do
+      qings[1].update!(
+        display_if: "all_met",
+        display_conditions_attributes: [
+          {left_qing: form.c[0], op: "gt", value: "5"}
+        ]
+      )
+      qings[2].update!(
+        display_if: "all_met",
+        display_conditions_attributes: [
+          {left_qing: form.c[0], op: "gt", value: "6"}
+        ]
+      )
+    end
+
+    scenario "editing several group conditions successively" do
+      visit(edit_url)
+      click_form_item_action_icon([1], :edit)
+      within(".modal") do
+        find(".condition-value input").set("15")
+        find(".btn-primary").click
+      end
+
+      click_form_item_action_icon([1], :edit)
+      within(".modal") do
+        expect(find(".condition-value input").value).to eq("15")
+        find(".btn-primary").click
+      end
+
+      click_form_item_action_icon([2], :edit)
+      within(".modal") do
+        expect(find(".condition-value input").value).to eq("6")
+        find(".condition-value input").set("16")
+        find(".btn-primary").click
+      end
+
+      click_form_item_action_icon([2], :edit)
+      within(".modal") do
+        expect(find(".condition-value input").value).to eq("16")
+      end
+    end
+  end
+
   def create_group(name)
     click_link("Add Group")
     fill_in("Name (English)", with: name)


### PR DESCRIPTION
Repro steps:
- Go to a form with multiple groups, including one at the root e.g. https://staging.getelmo.org/en/admin/forms/5e38b7c5-1f04-48f6-95e2-3d0946214abb/edit
- Click to edit the first group
- Close modal, then click to edit second group
- Note the Name field is correct but the Display Logic field is wrong

This fix is a bit hacky, but it's the simplest solution I could think of given the unusual combination of technology we have in this scenario:
- Rails creating a React component
- React component creating a Mobx store
- Same React component being re-created when the modal goes away and comes back, thus needing to re-create the store as well

Reason it wasn't working:
- When the React component was re-created, it asked for an instance of the store, and was given the old instance of the store from the store cache
- The old code worked just fine on pages that render one instance of each component, but modals are an exception because they go away and come back with different data
- The component in the modal successfully re-rendered, but showed the old store data

Reason the fix works:
- Now there's no store cache; the store is always created from scratch, so the data is correct

Reason for adding the new nonce:
- When the `DisplayLogicFormField/injector` component is re-created from scratch by Rails, it somehow tries to resume some aspect of its old state, causing Mobx to warn loudly about store replacement **if the store has changed** (the reason for adding the store cache in the first place)
- This resuming of state when completely re-created doesn't seem to be typical React behavior, and is possibly due to some complexity added by the interaction between React/Rails/Mobx
- In order to prevent Mobx from complaining on re-mount, we need to force the component to reset by giving it a **unique key** every time it's mounted by Rails
    - React uses `key` to reconcile the virtual dom; it's an easy and conventional way to tell React "this component is different than before"

Performance implications:
- Hardly any, because the component should have been doing this in the first place

Specs coming momentarily.