### PR TITLE
669: allow download of attached media with token

### DIFF
--- a/app/controllers/media/objects_controller.rb
+++ b/app/controllers/media/objects_controller.rb
@@ -6,6 +6,7 @@ module Media
     include Storage
 
     before_action :set_media_object, only: %i[show destroy]
+    before_action :authenticate_token, only: %i[show]
     skip_authorization_check
 
     def show
@@ -69,6 +70,11 @@ module Media
       when "images" then Media::Image
       else raise "A valid media type must be specified"
       end
+    end
+
+    def authenticate_token
+      user = authenticate_with_http_token { |token, _options| User.find_by(api_key: token) }
+      @current_user = user if user
     end
   end
 end


### PR DESCRIPTION
Allows to download attached media when user is not logged in but the API token is provided in the headers of the request.

Resolves #669