### PR TITLE
671: Show download link for media fields in API requests

### DIFF
--- a/app/serializers/api/v1/answer_serializer.rb
+++ b/app/serializers/api/v1/answer_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class API::V1::AnswerSerializer < ActiveModel::Serializer
   attributes :id, :code, :question, :value
   format_keys :underscore
@@ -15,6 +17,16 @@ class API::V1::AnswerSerializer < ActiveModel::Serializer
   end
 
   def value
-    object.casted_value
+    if %w[image audio video document].include?(object.qtype_name)
+      if object.media_object.present?
+        locale = configatron.key?(:preferred_locales) ? configatron.preferred_locales.first.to_s : "en"
+        media_object_path(id: object.media_object.id,
+                          locale: locale,
+                          mission_name: scope.params[:mission_name],
+                          type: object.qtype_name.pluralize)
+      end
+    else
+      object.casted_value
+    end
   end
 end


### PR DESCRIPTION
This suggestion adds the download link to API response requests on media fields, in the value field, which otherwise would be appearing as null.

Resolves #671