### PR TITLE
673: added skip authorization on option sets child nodes

### DIFF
--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -9,6 +9,7 @@ class OptionSetsController < ApplicationController
   # authorization via cancan
   load_and_authorize_resource
   skip_authorization_check only: :child_nodes
+  skip_authorize_resource only: :child_nodes
 
   decorates_assigned :option_sets
 


### PR DESCRIPTION
This commit solves the bug listed in #673 