### PR TITLE
10312: Make z-index important, add docs

### DIFF
--- a/app/assets/stylesheets/local/search/_filters.scss
+++ b/app/assets/stylesheets/local/search/_filters.scss
@@ -122,5 +122,7 @@
 }
 
 .filters-select2-dropdown {
-  z-index: 9999;
+  // Above popover, below tooltip.
+  // https://getbootstrap.com/docs/4.0/layout/overview/#z-index
+  z-index: 1065 !important;
 }


### PR DESCRIPTION
Fixes CSS ordering issue where select2.css is now imported after application.css so its values took precedence over our customization here.

<img width="473" alt="Screen Shot 2019-12-06 at 13 22 40" src="https://user-images.githubusercontent.com/2047062/70357394-a2ab0a00-182b-11ea-923c-dae6a47974f8.png">

Note for posterity: staging v9.23.1 does not experience this, so it must have been a change since then. Probably not worth spending more time on since this seems to be the only issue.