### PR TITLE
10330: Toggle password fields on render

### DIFF
--- a/app/assets/javascripts/views/user_profile_form_view.js.coffee
+++ b/app/assets/javascripts/views/user_profile_form_view.js.coffee
@@ -9,6 +9,7 @@ class ELMO.Views.UserProfileFormView extends ELMO.Views.ApplicationView
     @params = params || {}
     @init_user_group_select()
     @toggle_custom_gender_visibility()
+    @toggle_password_fields()
 
   init_user_group_select: ->
     option_builder = new ELMO.Utils.Select2OptionBuilder()


### PR DESCRIPTION
Fixes a long-standing bug where password fields were hidden if the page refreshed, e.g. when submitting a form that has errors. Previously they were only shown on a change in status of the select dropdown.