### PR TITLE
10404 wysiwyg icons

### DIFF
--- a/app/views/responses/answers/_single_editable.html.erb
+++ b/app/views/responses/answers/_single_editable.html.erb
@@ -44,7 +44,7 @@
     </div>
     <%= javascript_doc_ready do %>
       $('#<%= context.input_id(:value) %>').trumbowyg({
-        svgPath: '/assets/trumbowyg-icons.svg',
+        svgPath: '<%= image_path("trumbowyg-icons.svg") %>',
         lang: '<%= I18n.locale %>',
         autogrow: true,
         btns: [

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,9 @@ module ELMO
     # Something MUST be overriding it, but the documentation on it is sparse.
     config.assets.enabled = false
 
+    # Include images from vendor/assets/ too https://stackoverflow.com/a/14195512/763231
+    config.assets.precompile += %w[*.png *.jpg *.jpeg *.gif *.svg]
+
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = "1.0"
 


### PR DESCRIPTION
Webpacker seems not to include `vendor/assets/` images by default (based on https://stackoverflow.com/a/14195512/763231), this fixes that. Confirmed via:

```bash
NODE_ENV=production RAILS_ENV=production rails assets:precompile
find public/assets -name *.svg
```

The editor icons were working on staging, probably from stale assets... not sure why staging used stale assets and health got cleaned, but images definitely get compiled now locally.