### PR TITLE
10450 fix printable_form show [hotfix]

### DIFF
--- a/app/assets/javascripts/views/print_form_view.js
+++ b/app/assets/javascripts/views/print_form_view.js
@@ -61,8 +61,12 @@ ELMO.Views.PrintFormView = class PrintFormView extends ELMO.Views.ApplicationVie
     return window.print();
   }
 
+  // Returns a date in yyyy-mm-dd format.
   datestamp() {
+    // TODO: Clean up this logic with Moment when we migrate to package.json dependencies.
     const d = new Date();
-    return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${d.getFullYear()}-${month}-${day}`;
   }
 };

--- a/app/views/form_items/_printable.html.erb
+++ b/app/views/form_items/_printable.html.erb
@@ -3,6 +3,6 @@
     <%= render "questionings/printable", qing: item.decorate %>
   <% elsif item.is_a?(QingGroup) && item.children? %>
     <%= render "qing_groups/printable", qing_group: item %>
-    <%= render "form_items/printable", items: item.visible_and_enabled_children %>
+    <%= render "form_items/printable", items: item.visible_children %>
   <% end %>
 <% end %>

--- a/app/views/forms/_printable.html.erb
+++ b/app/views/forms/_printable.html.erb
@@ -12,6 +12,6 @@
       <td class="answer text_answer"><div class="answer_box"></div></td>
     </tr>
 
-    <%= render("form_items/printable", items: form.visible_and_enabled_children) %>
+    <%= render("form_items/printable", items: form.visible_children) %>
   </table>
 </div>

--- a/spec/features/forms/form/printable_spec.rb
+++ b/spec/features/forms/form/printable_spec.rb
@@ -14,22 +14,26 @@ feature "forms", js: true do
   end
 
   describe "print from index" do
-    scenario "should work and show tip the first time" do
-      visit(forms_path)
+    context "first time" do
+      before do
+        visit(forms_path)
+      end
 
-      # First time printing should show tips.
-      find("a.print-link").click
-      expect(page).to have_css("h4", text: "Print Format Tips")
+      it "should work and show tip" do
+        find("a.print-link").click
+        expect(page).to have_css("h4", text: "Print Format Tips")
+      end
     end
 
     context "with shown flag set" do
-      scenario "should not show tip" do
+      before do
         visit(forms_path)
-        expect(page).to have_content("Form")
-        date = Date.today.strftime("%Y-%m-%d")
-        page.execute_script("window.localStorage.setItem('form_print_format_tips_shown', '#{date}')")
 
-        # Second time printing should not show tips.
+        date = Time.zone.today.strftime("%Y-%m-%d")
+        page.execute_script("window.localStorage.setItem('form_print_format_tips_shown', '#{date}')")
+      end
+
+      it "should not show tip" do
         find("a.print-link").click
         expect(page).not_to have_css("h4", text: "Print Format Tips")
       end

--- a/spec/features/forms/form/printable_spec.rb
+++ b/spec/features/forms/form/printable_spec.rb
@@ -22,18 +22,17 @@ feature "forms", js: true do
       expect(page).to have_css("h4", text: "Print Format Tips")
     end
 
-    # Couldn't get this spec to work on headless chrome. Maybe it will work later.
-    # context "with shown flag set" do
-    #   scenario "should not show tip" do
-    #     visit(forms_path)
-    #     expect(page).to have_content('Form')
-    #     date = Date.today.strftime("%Y-%m-%d")
-    #     page.execute_script("window.localStorage.setItem('form_print_format_tips_shown', '#{date}')")
-    #
-    #     # Second time printing should not show tips.
-    #     find('a.print-link').click
-    #     expect(page).not_to have_css('h4', text: 'Print Format Tips')
-    #   end
-    # end
+    context "with shown flag set" do
+      scenario "should not show tip" do
+        visit(forms_path)
+        expect(page).to have_content("Form")
+        date = Date.today.strftime("%Y-%m-%d")
+        page.execute_script("window.localStorage.setItem('form_print_format_tips_shown', '#{date}')")
+
+        # Second time printing should not show tips.
+        find("a.print-link").click
+        expect(page).not_to have_css("h4", text: "Print Format Tips")
+      end
+    end
   end
 end

--- a/spec/features/forms/form/printable_spec.rb
+++ b/spec/features/forms/form/printable_spec.rb
@@ -17,11 +17,18 @@ feature "forms", js: true do
     context "first time" do
       before do
         visit(forms_path)
+        page.execute_script("localStorage.removeItem('form_print_format_tips_shown')")
       end
 
       it "should work and show tip" do
         find("a.print-link").click
         expect(page).to have_css("h4", text: "Print Format Tips")
+
+        click_button("OK")
+        wait_for_load
+
+        # Should still be on same page.
+        expect(current_url).to end_with("forms")
       end
     end
 
@@ -30,11 +37,12 @@ feature "forms", js: true do
         visit(forms_path)
 
         date = Time.zone.today.strftime("%Y-%m-%d")
-        page.execute_script("window.localStorage.setItem('form_print_format_tips_shown', '#{date}')")
+        page.execute_script("localStorage.setItem('form_print_format_tips_shown', '#{date}')")
       end
 
       it "should not show tip" do
         find("a.print-link").click
+        wait_for_load
         expect(page).not_to have_css("h4", text: "Print Format Tips")
       end
     end

--- a/spec/features/forms/form/printable_spec.rb
+++ b/spec/features/forms/form/printable_spec.rb
@@ -3,14 +3,23 @@
 require "rails_helper"
 
 feature "forms", js: true do
-  let!(:user) { create(:user) }
-  let!(:form) do
+  let(:user) { create(:user) }
+  let(:form) do
     create(:form, name: "Foo", question_types: %w[integer multilevel_select_one select_one integer])
   end
   let(:forms_path) { "/en/m/#{form.mission.compact_name}/forms" }
 
+  let!(:original_max) { Capybara.default_max_wait_time }
+
   before do
+    # Allow longer delays because specs were failing on Travis.
+    Capybara.default_max_wait_time = 10
+
     login(user)
+  end
+
+  after do
+    Capybara.default_max_wait_time = original_max
   end
 
   describe "print from index" do

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -105,6 +105,20 @@ module FeatureSpecHelpers
     page.evaluate_script("jQuery.active").zero?
   end
 
+  def wait_for_load_start
+    expect(page).to have_css("#glb-load-ind")
+  end
+
+  def wait_for_load_stop
+    expect(page).not_to have_css("#glb-load-ind")
+  end
+
+  def wait_for_load
+    # Should show, then hide the global loading indicator.
+    wait_for_load_start
+    wait_for_load_stop
+  end
+
   def select2(value, options = {})
     # invoke the select2 open action via JS
     execute_script("$('##{options[:from]}').select2('open')")


### PR DESCRIPTION
Changes:

- Fix method call that was renamed
- Wait for load in spec to make sure print page renders without error (this would have caught the original issue)
- Fix incorrect JS date format `2020-0-1` => `2020-01-01`
- Bring specs back from the dead (from https://github.com/thecartercenter/nemo/commit/f562a5c56438a675c72df8ae4435d031fd9818fd) now that they work with updated webdriver
- Clear localstorage to fix flapping spec
