### PR TITLE
10449 fix dashboard loading

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -38,6 +38,12 @@
       if (!ajaxopts.url.match(/\bauto=1\b/)) self.reset_session_countdown();
     });
 
+    // Signal when the user is navigating to a different page, because that
+    // causes XHR requests to fail in some browsers, and we can ignore those failures.
+    $(window).on('beforeunload', () => {
+      ELMO.unloading = true;
+    });
+
     // prevent double submission of any forms on the page
     $('form').preventDoubleSubmission();
 

--- a/app/assets/javascripts/legacy/controllers/report/report_controller.js
+++ b/app/assets/javascripts/legacy/controllers/report/report_controller.js
@@ -107,6 +107,7 @@
   };
 
   klass.prototype.run_error = function (jqxhr, status, error) {
+    if (ELMO.unloading) return;
     this.restore_view();
     // show error
     const msg = I18n.t(`layout.${error == '' ? 'server_contact_error' : 'system_error'}`);

--- a/app/assets/javascripts/legacy/views/dashboard.js
+++ b/app/assets/javascripts/legacy/views/dashboard.js
@@ -139,6 +139,7 @@
         self.reload_timer = setTimeout(() => { self.reload_ajax(); }, AJAX_RELOAD_INTERVAL * 1000);
       },
       error() {
+        if (ELMO.unloading) return;
         $('#content').html(I18n.t('layout.server_contact_error'));
       },
     });

--- a/app/assets/javascripts/legacy/views/option_set_form.js
+++ b/app/assets/javascripts/legacy/views/option_set_form.js
@@ -279,7 +279,8 @@
           $('.elmo-form-wrapper').replaceWith(jqxhr.responseText);
         }
       },
-      error(jqxhr) {
+      error() {
+        if (ELMO.unloading) return;
         // if we get an HTTP error, it's some server thing so just display a generic message
         $('.elmo-form-wrapper').replaceWith('Server Error');
         // Stop loading

--- a/app/assets/javascripts/views/dashboard_map_view.js
+++ b/app/assets/javascripts/views/dashboard_map_view.js
@@ -128,8 +128,13 @@ ELMO.Views.DashboardMapView = class DashboardMapView extends ELMO.Views.Applicat
         url: this.params.info_window_url,
         method: 'get',
         data: { response_id: marker.r_id },
-        success(data) { return $('div.info_window').replaceWith(data); },
-        error() { return $('div.info_window').html(I18n.t('layout.server_contact_error')); },
+        success(data) {
+          $('div.info_window').replaceWith(data);
+        },
+        error() {
+          if (ELMO.unloading) return;
+          $('div.info_window').html(I18n.t('layout.server_contact_error'));
+        },
       });
     });
   }

--- a/app/assets/javascripts/views/regenerable_field_view.js
+++ b/app/assets/javascripts/views/regenerable_field_view.js
@@ -45,6 +45,7 @@ ELMO.Views.RegenerableFieldView = class RegenerableFieldView extends ELMO.Views.
         return successIndicator.show();
       },
       error() {
+        if (ELMO.unloading) return;
         inlineLoadInd.hide();
         return errorIndicator.show();
       },


### PR DESCRIPTION
### Change

Use `ELMO.unloading` in `beforeunload` to skip XHR error handling when user is navigating. The error can be reproduced on current Firefox, but **not** on current Chrome (navigation errors are gracefully ignored).

- URL to trigger 3s delay + eventual CORS error: `http://slowwly.robertomurray.co.uk/delay/3000/url/https://www.google.com`
- URL to trigger immediate 503: `/ping`

### Other workarounds suggested on the interwebs

```js
if (xhr.status != 0) // not reliable
if (xhr.readyState < 4) // not reliable
if (!xhr.getAllResponseHeaders()) // not reliable
.on("unload", () => App.unloading = true) // not reliable
.on("unload", () => reqs.each((req) => req.abort())) // track open requests manually
.error((xhr) => setTimeout(() => { handle }, 1000)) // at least error won't happen right away
ajax({ async: false }) // deprecated
```

### Examples of data returned by various types of errors

#### Real error (Chrome):
```json
error: "Service Unavailable"
status: "error"
jqStatus: 503
readyState: 4
getAllResponseHeaders: "cache-control: no-cache ..."
```

#### CORS error (Chrome):
```json
error: ""
status: "error"
jqStatus: 0
readyState: 0
getAllResponseHeaders: ""
```

#### User navigation error (FireFox):
```json
error: ""​
status: "error"
​jqStatus: 0
​readyState: 0
​getAllResponseHeaders: ""
```

#### User navigation error (Chrome):
```
nothing, it drops the request automatically and doesn't complain
```
