### PR TITLE
10470: Fix inline hint css class application

### DIFF
--- a/app/views/layouts/_elmo_form_field.html.erb
+++ b/app/views/layouts/_elmo_form_field.html.erb
@@ -7,7 +7,7 @@
   <div class="control <%= options[:read_only] ? 'read-only' : '' %>">
     <%# errors %>
     <%= content_tag(:div, errors.join(' '), :class => 'form-errors') if errors.present? %>
-    <div class="widget<%= inline_hint_html ? " inline-hint" : "" %>">
+    <div class="widget<%= inline_hint_html.present? ? " inline-hint" : "" %>">
       <%= field_html %>
       <%= inline_hint_html %>
     </div>


### PR DESCRIPTION
I think this was just a little bug that crept in recently. Noticed it on option set form:

![image](https://user-images.githubusercontent.com/702320/75064955-e53cc400-54b5-11ea-82c8-be857089b92e.png)
