### PR TITLE
10446 disallow blank group name

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,6 +9,7 @@ globals:
   _: true
   I18n: true
   ELMO: true
+  ReactRailsUJS: true
   Backbone: true
   Dropzone: true
   google: true

--- a/app/assets/javascripts/legacy/views/draggable_list.js
+++ b/app/assets/javascripts/legacy/views/draggable_list.js
@@ -48,7 +48,7 @@
 
     // Catch modal form submission.
     self.modal.on('keypress', (event) => {
-      if (event.keyCode == 13) {
+      if (event.key === 'Enter') {
         event.preventDefault(); // Prevent submission of the containing form.
         const btn = self.modal.find('.btn-primary').last();
         if (btn.is(':visible')) btn.trigger('click');
@@ -57,7 +57,7 @@
 
     // Catch ESC key to prevent closing parent modal if exists.
     self.modal.on('keydown', (event) => {
-      if (event.keyCode == 27) {
+      if (event.key === 'Escape') {
         event.stopPropagation();
         self.modal.modal('hide');
       }

--- a/app/assets/javascripts/legacy/views/report/edit_view.js
+++ b/app/assets/javascripts/legacy/views/report/edit_view.js
@@ -63,9 +63,8 @@
 
     this.show_pane(idx);
 
-    // hookup esc key
     if (!this.report.new_record) {
-      this.esc_handler = function (e) { if (e.keyCode === 27) _this.cancel(); };
+      this.esc_handler = function (e) { if (e.key === 'Escape') _this.cancel(); };
       $(document).bind('keyup', this.esc_handler);
     }
   };

--- a/app/assets/javascripts/views/group_modal_view.js
+++ b/app/assets/javascripts/views/group_modal_view.js
@@ -36,7 +36,7 @@ ELMO.Views.GroupModalView = class GroupModalView extends ELMO.Views.FormView {
   }
 
   keypress(e) {
-    if (e.keyCode === 13) { // Enter
+    if (e.key === 'Enter') {
       e.preventDefault();
       return this.save();
     }

--- a/app/assets/javascripts/views/group_modal_view.js
+++ b/app/assets/javascripts/views/group_modal_view.js
@@ -50,8 +50,6 @@ ELMO.Views.GroupModalView = class GroupModalView extends ELMO.Views.FormView {
     } else if (this.mode === 'edit') {
       this.edit_group();
     }
-
-    return this.hide();
   }
 
   show() {
@@ -76,7 +74,11 @@ ELMO.Views.GroupModalView = class GroupModalView extends ELMO.Views.FormView {
       data: this.form_data,
       success: (data) => {
         this.list_view.add_new_group(data);
-        return ELMO.app.loading(false);
+        this.hide();
+      },
+      error: this.replaceModalBody,
+      complete: () => {
+        ELMO.app.loading(false);
       },
     });
   }
@@ -90,9 +92,18 @@ ELMO.Views.GroupModalView = class GroupModalView extends ELMO.Views.FormView {
       data: this.form_data,
       success: (data) => {
         this.list_view.update_group_on_edit(data);
-        return ELMO.app.loading(false);
+        this.hide();
+      },
+      error: this.replaceModalBody,
+      complete: () => {
+        ELMO.app.loading(false);
       },
     });
+  }
+
+  replaceModalBody = ({ responseText }) => {
+    this.$('.modal-body').replaceWith(responseText);
+    ReactRailsUJS.mountComponents('.modal-body');
   }
 
   toggle_item_name() {

--- a/app/assets/javascripts/views/return_to_draft_view.js
+++ b/app/assets/javascripts/views/return_to_draft_view.js
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 // Controls "return to draft status" button and modal.
 ELMO.Views.ReturnToDraftView = class ReturnToDraftView extends ELMO.Views.ApplicationView {
   get el() { return '#action-links-and-modal'; }
@@ -18,30 +13,33 @@ ELMO.Views.ReturnToDraftView = class ReturnToDraftView extends ELMO.Views.Applic
 
   initialize(params) {
     this.keyword = params.keyword;
-    this.$('#override').val(''); // Ensure box is empty in case cached.
-    return this.accepted = false;
+    // Ensure box is empty in case cached.
+    this.$('#override').val('');
+    this.accepted = false;
   }
 
   handleLinkClicked(event) {
-    // If accept button was clicked, we just let the link do it's thing.
-    if (this.accepted) { return; }
+    // If accept button was clicked, we just let the link do its thing.
+    if (this.accepted) return;
 
+    // Otherwise show the modal instead.
     event.preventDefault();
     event.stopPropagation();
-    return this.$('#return-to-draft-modal').modal('show');
+    this.$('#return-to-draft-modal').modal('show');
   }
 
-  handleModalShown(event) {
-    return this.$('#override').focus();
+  handleModalShown() {
+    this.$('#override').focus();
   }
 
   handleKeyup(event) {
-    return this.$('.btn-primary').toggle(this.$(event.target).val() === this.keyword);
+    const correctKeyword = this.$(event.target).val() === this.keyword;
+    this.$('.btn-primary').toggle(correctKeyword);
   }
 
-  handleAcceptClicked(event) {
+  handleAcceptClicked() {
     this.accepted = true;
     // Trigger another click on the link so we can use the data-method machinery to make the PUT request.
-    return this.$('.return-to-draft-link').trigger('click');
+    this.$('.return-to-draft-link').trigger('click');
   }
 };

--- a/app/assets/javascripts/views/return_to_draft_view.js
+++ b/app/assets/javascripts/views/return_to_draft_view.js
@@ -7,6 +7,7 @@ ELMO.Views.ReturnToDraftView = class ReturnToDraftView extends ELMO.Views.Applic
       'click .return-to-draft-link': 'handleLinkClicked',
       'shown.bs.modal #return-to-draft-modal': 'handleModalShown',
       'click #return-to-draft-modal .btn-primary': 'handleAcceptClicked',
+      'keypress #override': 'handleKeypress',
       'keyup #override': 'handleKeyup',
     };
   }
@@ -32,14 +33,23 @@ ELMO.Views.ReturnToDraftView = class ReturnToDraftView extends ELMO.Views.Applic
     this.$('#override').focus();
   }
 
-  handleKeyup(event) {
-    const correctKeyword = this.$(event.target).val() === this.keyword;
-    this.$('.btn-primary').toggle(correctKeyword);
+  handleKeypress(event) {
+    if (event.key === 'Enter' && this.isCorrectKeyword()) {
+      this.$('#return-to-draft-modal .btn-primary').trigger('click');
+    }
+  }
+
+  handleKeyup() {
+    this.$('.btn-primary').toggle(this.isCorrectKeyword());
   }
 
   handleAcceptClicked() {
     this.accepted = true;
     // Trigger another click on the link so we can use the data-method machinery to make the PUT request.
     this.$('.return-to-draft-link').trigger('click');
+  }
+
+  isCorrectKeyword() {
+    return this.$('#override').val() === this.keyword;
   }
 };

--- a/app/models/qing_group.rb
+++ b/app/models/qing_group.rb
@@ -55,6 +55,9 @@ class QingGroup < FormItem
 
   delegate :standard_copy?, :published?, to: :form
 
+  # Don't require a name for root groups.
+  validates :group_name, presence: true, if: -> { parent.present? }
+
   alias c sorted_children
 
   def code

--- a/app/models/qing_group.rb
+++ b/app/models/qing_group.rb
@@ -55,8 +55,7 @@ class QingGroup < FormItem
 
   delegate :standard_copy?, :published?, to: :form
 
-  # Don't require a name for root groups.
-  validates :group_name, presence: true, if: -> { parent.present? }
+  validates :group_name, presence: true, unless: -> { root? }
 
   alias c sorted_children
 

--- a/app/views/qing_groups/_modal.html.erb
+++ b/app/views/qing_groups/_modal.html.erb
@@ -8,32 +8,8 @@
         <button type="button" class="close group-cancel" data-dismiss="modal" aria-hidden="true">&times;</button>
       </div>
 
-      <div class="modal-body group-form">
-        <%= Forms::IntegrityWarnings::Builder.new(@qing_group) %>
-        <%= elmo_form_for(@qing_group) do |f| %>
-          <%= f.field(:form_id, type: :hidden) %>
-          <%= f.field(:repeatable, type: :check_box) %>
-          <% configatron.preferred_locales.each do |locale| %>
-            <% lang_suffix = " (#{language_name(locale)})" %>
-            <%= f.field(:"group_name_#{locale}",
-                label: QingGroup.human_attribute_name("group_name") + lang_suffix) %>
-            <%= f.field(:"group_hint_#{locale}",
-                label: QingGroup.human_attribute_name("group_hint") + lang_suffix) %>
-            <%= f.field(:"group_item_name_#{locale}",
-                label: QingGroup.human_attribute_name("group_item_name") + lang_suffix,
-                hint: t("activerecord.hints.qing_group.group_item_name")) %>
-          <% end %>
-          <% if @one_screen_disabled %>
-            <%= f.field(:one_screen, content: t("qing_group.one_screen_disabled")) %>
-            <%= f.hidden_field(:one_screen) %>
-          <% else %>
-            <%= f.field(:one_screen, type: :check_box) %>
-          <% end %>
-          <%= f.field(:display_logic,
-                partial: "questionings/display_logic",
-                locals: {form_item: @qing_group}) %>
-        <% end %>
-      </div>
+      <%= render(partial: "modal_body") %>
+
       <% if action_name != "show" %>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary cancel" data-dismiss="modal">

--- a/app/views/qing_groups/_modal_body.html.erb
+++ b/app/views/qing_groups/_modal_body.html.erb
@@ -1,0 +1,26 @@
+<div class="modal-body group-form">
+  <%= Forms::IntegrityWarnings::Builder.new(@qing_group) %>
+  <%= elmo_form_for(@qing_group) do |f| %>
+    <%= f.field(:form_id, type: :hidden) %>
+    <%= f.field(:repeatable, type: :check_box) %>
+    <% configatron.preferred_locales.each do |locale| %>
+      <% lang_suffix = " (#{language_name(locale)})" %>
+      <%= f.field(:"group_name_#{locale}",
+          label: QingGroup.human_attribute_name("group_name") + lang_suffix) %>
+      <%= f.field(:"group_hint_#{locale}",
+          label: QingGroup.human_attribute_name("group_hint") + lang_suffix) %>
+      <%= f.field(:"group_item_name_#{locale}",
+          label: QingGroup.human_attribute_name("group_item_name") + lang_suffix,
+          hint: t("activerecord.hints.qing_group.group_item_name")) %>
+    <% end %>
+    <% if @one_screen_disabled %>
+      <%= f.field(:one_screen, content: t("qing_group.one_screen_disabled")) %>
+      <%= f.hidden_field(:one_screen) %>
+    <% else %>
+      <%= f.field(:one_screen, type: :check_box) %>
+    <% end %>
+    <%= f.field(:display_logic,
+          partial: "questionings/display_logic",
+          locals: {form_item: @qing_group}) %>
+  <% end %>
+</div>

--- a/app/views/qing_groups/_modal_body.html.erb
+++ b/app/views/qing_groups/_modal_body.html.erb
@@ -1,6 +1,7 @@
 <div class="modal-body group-form">
   <%= Forms::IntegrityWarnings::Builder.new(@qing_group) %>
   <%= elmo_form_for(@qing_group) do |f| %>
+    <%= f.base_errors %>
     <%= f.field(:form_id, type: :hidden) %>
     <%= f.field(:repeatable, type: :check_box) %>
     <% configatron.preferred_locales.each do |locale| %>

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -111,7 +111,8 @@ def build_item(item, form, parent, evaluator)
     group = create(:qing_group,
       parent: parent,
       form: form,
-      group_name_en: item[:name],
+      # Group name is required, but may not be defined on `item`.
+      group_name_en: item[:name] || "Group #{rand(100_000)}",
       group_hint_en: item[:name],
       group_item_name: item[:item_name],
       repeatable: true)

--- a/spec/features/forms/form_item/qing_group_form_spec.rb
+++ b/spec/features/forms/form_item/qing_group_form_spec.rb
@@ -14,56 +14,80 @@ feature "adding and editing qing group on form", js: true do
     login(user)
   end
 
-  scenario "add a new group to a form" do
-    visit(edit_form_path(form, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+  context "adding a new group to a form" do
+    before do
+      visit(edit_form_path(form, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+      click_link("Add Group")
+    end
 
-    click_link("Add Group")
-    fill_in("Name (English)", with: "Foo Group")
-    fill_in("Hint (English)", with: "Bar Hint")
-    fill_in("Name (Français)", with: "Fou Groupe")
-    fill_in("Hint (Français)", with: "Barre Hinte")
+    scenario "happy path" do
+      fill_in("Name (English)", with: "Foo Group")
+      fill_in("Hint (English)", with: "Bar Hint")
+      fill_in("Name (Français)", with: "Fou Groupe")
+      fill_in("Hint (Français)", with: "Barre Hinte")
 
-    # Test display conditions when creating new group
-    select("Display this group if all of these conditions are met", from: "qing_group_display_logic")
-    find(".add-condition")
-    find('select[name$="[left_qing_id]"]').select(form.c[0].code)
-    find('select[name$="[op]"]').select("= equals")
-    find('input[name$="[value]"]').set("3")
+      # Test display conditions when creating new group
+      select("Display this group if all of these conditions are met", from: "qing_group_display_logic")
+      find(".add-condition")
+      find('select[name$="[left_qing_id]"]').select(form.c[0].code)
+      find('select[name$="[op]"]').select("= equals")
+      find('input[name$="[value]"]').set("3")
 
-    expect(page).not_to have_content("Item Name (English)")
-    check("qing_group_repeatable")
-    fill_in("Item Name (English)", with: "Test Name")
-    fill_in("Item Name (Français)", with: "Nom d'essaie")
-    uncheck("qing_group_one_screen")
-    within(".modal") { click_button("Save") }
+      expect(page).not_to have_content("Item Name (English)")
+      check("qing_group_repeatable")
+      fill_in("Item Name (English)", with: "Test Name")
+      fill_in("Item Name (Français)", with: "Nom d'essaie")
+      uncheck("qing_group_one_screen")
+      within(".modal") { click_button("Save") }
 
-    within(".form-items") { expect(page).to have_content("Foo Group") }
-    all(".form-items .action-link.action-link-edit")[-1].click
-    expect(page).to have_field("qing_group_group_name_en", with: "Foo Group")
-    expect(page).to have_field("qing_group_group_name_fr", with: "Fou Groupe")
-    expect(page).to have_field("qing_group_group_hint_en", with: "Bar Hint")
-    expect(page).to have_field("qing_group_group_hint_fr", with: "Barre Hinte")
-    expect(page).to have_field("qing_group_repeatable", checked: true)
-    expect(page).to have_field("qing_group_one_screen", checked: false)
-    expect(page).to have_field("qing_group_group_item_name_en", with: "Test Name")
-    expect(page).to have_field("qing_group_group_item_name_fr", with: "Nom d'essaie")
+      within(".form-items") { expect(page).to have_content("Foo Group") }
+      all(".form-items .action-link.action-link-edit")[-1].click
+      expect(page).to have_field("qing_group_group_name_en", with: "Foo Group")
+      expect(page).to have_field("qing_group_group_name_fr", with: "Fou Groupe")
+      expect(page).to have_field("qing_group_group_hint_en", with: "Bar Hint")
+      expect(page).to have_field("qing_group_group_hint_fr", with: "Barre Hinte")
+      expect(page).to have_field("qing_group_repeatable", checked: true)
+      expect(page).to have_field("qing_group_one_screen", checked: false)
+      expect(page).to have_field("qing_group_group_item_name_en", with: "Test Name")
+      expect(page).to have_field("qing_group_group_item_name_fr", with: "Nom d'essaie")
 
-    # Test display condition saved. Detailed test is in display_conditions_form_spec
-    expect(page).to have_select("qing_group_display_logic",
-      selected: "Display this group if all of these conditions are met")
+      # Test display condition saved. Detailed test is in display_conditions_form_spec
+      expect(page).to have_select("qing_group_display_logic",
+        selected: "Display this group if all of these conditions are met")
 
-    fill_in("Name (English)", with: "New Group Name")
-    within(".modal") { click_button("Save") }
-    within(".form-items") { expect(page).to have_content("New Group Name") }
-  end
+      fill_in("Name (English)", with: "New Group Name")
+      within(".modal") { click_button("Save") }
+      within(".form-items") { expect(page).to have_content("New Group Name") }
+    end
 
-  scenario "add a new group to a form (blank name)" do
-    visit(edit_form_path(form, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+    scenario "with blank name" do
+      fill_in("Name (English)", with: "")
+      within(".modal") { click_button("Save") }
 
-    click_link("Add Group")
-    fill_in("Name (English)", with: "")
-    within(".modal") { click_button("Save") }
+      expect(page).to have_content("This field is required")
+    end
 
-    expect(page).to have_content("This field is required")
+    context "then editing" do
+      before do
+        fill_in("Name (English)", with: "Foo Group")
+        within(".modal") { click_button("Save") }
+
+        find("li.form-item-group").click
+      end
+
+      scenario "happy path" do
+        fill_in("Name (English)", with: "something else")
+        within(".modal") { click_button("Save") }
+
+        within(".form-items") { expect(page).to have_content("something else") }
+      end
+
+      scenario "with blank name" do
+        fill_in("Name (English)", with: "")
+        within(".modal") { click_button("Save") }
+
+        expect(page).to have_content("This field is required")
+      end
+    end
   end
 end

--- a/spec/features/forms/form_item/qing_group_form_spec.rb
+++ b/spec/features/forms/form_item/qing_group_form_spec.rb
@@ -56,4 +56,14 @@ feature "adding and editing qing group on form", js: true do
     within(".modal") { click_button("Save") }
     within(".form-items") { expect(page).to have_content("New Group Name") }
   end
+
+  scenario "add a new group to a form (blank name)" do
+    visit(edit_form_path(form, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+
+    click_link("Add Group")
+    fill_in("Name (English)", with: "")
+    within(".modal") { click_button("Save") }
+
+    expect(page).to have_content("This field is required")
+  end
 end


### PR DESCRIPTION
There are multiple possible "name" fields due to i18n, so they can't be marked "mandatory", and errors won't render automatically above the custom field. So `group_name` errors are bubbled up and rendered as base errors on the form.

There's also a bit of JS cleanup included.

<img width="807" alt="Screen Shot 2020-03-16 at 14 54 45" src="https://user-images.githubusercontent.com/2047062/76803439-15b30d80-6797-11ea-9e43-27e33ef0ede0.png">
