### PR TITLE
10594 odata metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GIT
 
 GIT
   remote: https://github.com/sassafrastech/odata_server.git
-  revision: a194c4847ee2442f8e2c288933de39260f4ff834
+  revision: d50d523353c34aebe635f90be45685a03d26818e
   branch: sassafras
   specs:
     odata_server (0.1.0)

--- a/app/models/o_data/question_type.rb
+++ b/app/models/o_data/question_type.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module OData
+  # Wraps a QuestionType for rendering as OData.
+  class QuestionType
+    attr_accessor :question_type
+
+    delegate :name, to: :question_type
+
+    # Map from QuestionType to OData type.
+    ODATA_TYPES = {
+      "text" => :string,
+      "long_text" => :string,
+      "barcode" => :string,
+      "integer" => :integer,
+      "counter" => :integer,
+      "decimal" => :decimal,
+      "location" => :string,
+      "select_one" => :string,
+      "select_multiple" => :string,
+      "datetime" => :datetime,
+      "date" => :date,
+      "time" => :time,
+      "image" => :string,
+      "annotated_image" => :string,
+      "signature" => :string,
+      "sketch" => :string,
+      "audio" => :string,
+      "video" => :string
+    }.freeze
+
+    def initialize(question_type)
+      self.question_type = question_type
+    end
+
+    def odata_type
+      ODATA_TYPES[name]
+    end
+  end
+end

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -54,7 +54,8 @@ module OData
     end
 
     def child_qing(child)
-      [child.name, child.qtype.odata_type.to_sym]
+      qtype = OData::QuestionType.new(child.qtype)
+      [child.name, qtype.odata_type]
     end
 
     # Return the OData EntityType name for a group based on its nesting.

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module OData
+  # Represents all the OData entities for our metadata.
   class SimpleEntities
     attr_reader :values
 

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -49,6 +49,7 @@ module OData
       build_nested_children(parent: child, parent_name: entity_name, children: children)
       child_name = "#{SimpleSchema::NAMESPACE}.#{entity_name}"
       child_type = child.repeatable? ? "Collection(#{child_name})" : child_name
+      # TODO: Remove `(group_number)` once we use unique group_code in an upcoming commit.
       ["#{child.group_name} (#{group_number})", child_type]
     end
 

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -4,6 +4,16 @@ module OData
   class SimpleEntities
     attr_reader :values
 
+    # TODO:
+    #       <EntityType Name="Response.Form_C" BaseType="Demo.Response">
+    #         <Property Name="City" Type="Edm.String"/>
+    #         <Property Name="HouseholdMembers" Type="Collection(Demo.Repeat.Form_C.R1)"/>
+    #       </EntityType>
+    #       <EntityType Name="Repeat.Form_B.R1">
+    #         <Property Name="FullName" Type="Edm.String"/>
+    #         <Property Name="Age" Type="Edm.Int64"/>
+    #         <Property Name="Eyes" Type="Collection(Demo.Repeat.Form_B.R2)"/>
+    #       </EntityType>
     def initialize(distinct_forms)
       base_entity = SimpleEntity.new("Response", key_name: "ResponseID",
                                                  property_types: {
@@ -18,8 +28,11 @@ module OData
       base_type = "#{ODataController::NAMESPACE}.Response"
 
       response_entities = distinct_forms.map do |form|
-        property_types = form.questions.map do |q|
-          [q.name, q.qtype.odata_type.to_sym]
+        repeat_number = 0
+        property_types = form.c.map do |c|
+          c.is_a?(Questioning) ?
+            [c.name, c.qtype.odata_type.to_sym] :
+            [c.group_name, "Collection(#{ODataController::NAMESPACE}.Repeat.#{form.name}.R#{repeat_number += 1})"]
         end.to_h
         SimpleEntity.new("Responses: #{form.name}", extra_tags: {BaseType: base_type},
                                                     property_types: property_types)

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -4,11 +4,9 @@ module OData
   class SimpleEntities
     attr_reader :values
 
-    def initialize
-      # TODO: All published forms in the missions, regardless of if they have response
-      @values = Response.distinct.pluck(:form_id).map do |id|
-        name = Form.find(id).name
-        SimpleEntity.new("Responses: #{name}")
+    def initialize(distinct_forms)
+      @values = distinct_forms.map do |form|
+        SimpleEntity.new("Responses: #{form.name}")
       end
     end
   end

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -5,45 +5,55 @@ module OData
   class SimpleEntities
     attr_reader :values
 
-    def initialize(distinct_forms)
-      base_entity = SimpleEntity.new("Response", key_name: "ResponseID",
-                                                 property_types: {
-                                                   ResponseSubmitDate: :datetime,
-                                                   ResponseSubmitterName: :string,
-                                                   ResponseID: :id,
-                                                   ResponseShortcode: :string,
-                                                   ResponseReviewed: :boolean,
-                                                   FormName: :string
-                                                 })
-      # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
-      base_type = "#{ODataController::NAMESPACE}.Response"
+    RESPONSE_BASE_PROPERTIES = {
+      ResponseSubmitDate: :datetime,
+      ResponseSubmitterName: :string,
+      ResponseID: :id,
+      ResponseShortcode: :string,
+      ResponseReviewed: :boolean,
+      FormName: :string
+    }.freeze
 
+    def initialize(distinct_forms)
+      response_base = SimpleEntity.new("Response", key_name: "ResponseID",
+                                                   property_types: RESPONSE_BASE_PROPERTIES)
       response_entities = distinct_forms.map do |form|
-        add_children(parent: form, parent_name: "Responses: #{form.name}", base_type: base_type, root_name: form.name)
+        build_nested_children(parent: form,
+                              parent_name: "Responses: #{form.name}",
+                              base_type: "#{ODataController::NAMESPACE}.Response",
+                              root_name: form.name)
       end.flatten
 
-      @values = [base_entity] + response_entities
+      @values = [response_base] + response_entities
     end
 
-    # Add an Entity for each of the parent's children,
-    # recursing into groups.
-    def add_children(parent:, parent_name:, base_type: nil, root_name: nil, children: [])
+    # Add an Entity for each of the parent's children, recursing into groups.
+    def build_nested_children(parent:, parent_name:, base_type: nil, root_name: nil, children: [])
       group_number = 0
-      property_types = parent.c.map do |c|
-        if c.is_a?(QingGroup)
+      property_types = parent.c.map do |child|
+        if child.is_a?(QingGroup)
           group_number += 1
-          entity_name = get_entity_name(root_name, group_number, parent_name)
-          add_children(parent: c, parent_name: entity_name, children: children)
-          child_name = "#{ODataController::NAMESPACE}.#{entity_name}"
-          child_type = c.repeatable? ? "Collection(#{child_name})" : child_name
-          ["#{c.group_name} (#{group_number})", child_type]
+          child_qing_group(child, group_number: group_number, parent_name: parent_name,
+                                  root_name: root_name, children: children)
         else
-          [c.name, c.qtype.odata_type.to_sym]
+          child_qing(child)
         end
       end.to_h
 
       children.push(SimpleEntity.new(parent_name, extra_tags: base_type ? {BaseType: base_type} : {},
                                                   property_types: property_types))
+    end
+
+    def child_qing_group(child, group_number:, parent_name:, root_name:, children:)
+      entity_name = get_entity_name(root_name, group_number, parent_name)
+      build_nested_children(parent: child, parent_name: entity_name, children: children)
+      child_name = "#{ODataController::NAMESPACE}.#{entity_name}"
+      child_type = child.repeatable? ? "Collection(#{child_name})" : child_name
+      ["#{child.group_name} (#{group_number})", child_type]
+    end
+
+    def child_qing(child)
+      [child.name, child.qtype.odata_type.to_sym]
     end
 
     # Return the OData EntityType name for a group based on its nesting.

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -4,10 +4,37 @@ module OData
   class SimpleEntities
     attr_reader :values
 
+    # TODO:
+    #      <EntityType Name="Response">
+    #         <Key>
+    #           <PropertyRef Name="ResponseID"/>
+    #         </Key>
+    #         <Property Name="ResponseSubmitDate" Type="Edm.DateTimeOffset"/>
+    #         <Property Name="ResponseSubmitterName" Type="Edm.String"/>
+    #         <Property Name="ResponseID" Type="Edm.String"/>
+    #         <Property Name="ResponseShortcode" Type="Edm.String"/>
+    #         <Property Name="ResponseReviewed" Type="Edm.Boolean"/>
+    #         <Property Name="FormName" Type="Edm.String"/>
+    #       </EntityType>
+    #       <EntityType Name="Response.Form_A" BaseType="Demo.Response">
+    #         <Property Name="FullName" Type="Edm.String"/>
+    #         <Property Name="Age" Type="Edm.Int64"/>
+    #       </EntityType>
     def initialize(distinct_forms)
-      @values = distinct_forms.map do |form|
-        SimpleEntity.new("Responses: #{form.name}")
+      base_entity = SimpleEntity.new("Response", key_name: "ResponseID",
+                                                 properties: {
+                                                   ResponseID: SimpleProperty.new
+                                                 })
+      # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
+      base_type = "#{ODataController::NAMESPACE}.Response"
+      response_entities = distinct_forms.map do |form|
+        SimpleEntity.new("Responses: #{form.name}", extra_tags: {BaseType: base_type},
+                                                    properties: {
+                                                      ID: SimpleProperty.new
+                                                    })
       end
+
+      @values = [base_entity] + response_entities
     end
   end
 end

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -31,9 +31,11 @@ module OData
       property_types = parent.c.map do |c|
         if c.is_a?(QingGroup)
           repeat_number += 1
-          name = get_repeat_name(root_name, repeat_number, parent_name)
-          add_children(parent: c, parent_name: name, children: children)
-          [c.group_name, "Collection(#{ODataController::NAMESPACE}.#{name})"]
+          entity_name = get_entity_name(root_name, repeat_number, parent_name)
+          add_children(parent: c, parent_name: entity_name, children: children)
+          child_name = "#{ODataController::NAMESPACE}.#{entity_name}"
+          child_type = c.repeatable? ? "Collection(#{child_name})" : child_name
+          [c.group_name, child_type]
         else
           [c.name, c.qtype.odata_type.to_sym]
         end
@@ -43,8 +45,8 @@ module OData
                                                   property_types: property_types))
     end
 
-    # Return the OData EntityType name for a repeat group based on its nesting.
-    def get_repeat_name(root_name, repeat_number, parent_name)
+    # Return the OData EntityType name for a group based on its nesting.
+    def get_entity_name(root_name, repeat_number, parent_name)
       if root_name
         # The first level of repeats starts with the word "Repeat"
         "Repeat.#{root_name}.R#{repeat_number}"

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -35,7 +35,7 @@ module OData
           add_children(parent: c, parent_name: entity_name, children: children)
           child_name = "#{ODataController::NAMESPACE}.#{entity_name}"
           child_type = c.repeatable? ? "Collection(#{child_name})" : child_name
-          [c.group_name, child_type]
+          ["#{c.group_name} (#{group_number})", child_type]
         else
           [c.name, c.qtype.odata_type.to_sym]
         end

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module OData
+  class SimpleEntities
+    attr_reader :values
+
+    def initialize
+      # TODO: All published forms in the missions, regardless of if they have response
+      @values = Response.distinct.pluck(:form_id).map do |id|
+        name = Form.find(id).name
+        SimpleEntity.new("Responses: #{name}")
+      end
+    end
+  end
+end

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -4,11 +4,6 @@ module OData
   class SimpleEntities
     attr_reader :values
 
-    # TODO:
-    #       <EntityType Name="Response.Form_A" BaseType="Demo.Response">
-    #         <Property Name="FullName" Type="Edm.String"/>
-    #         <Property Name="Age" Type="Edm.Int64"/>
-    #       </EntityType>
     def initialize(distinct_forms)
       base_entity = SimpleEntity.new("Response", key_name: "ResponseID",
                                                  property_types: {
@@ -21,10 +16,13 @@ module OData
                                                  })
       # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
       base_type = "#{ODataController::NAMESPACE}.Response"
+
       response_entities = distinct_forms.map do |form|
+        property_types = form.questions.map do |q|
+          [q.name, q.qtype.odata_type.to_sym]
+        end.to_h
         SimpleEntity.new("Responses: #{form.name}", extra_tags: {BaseType: base_type},
-                                                    property_types: {
-                                                    })
+                                                    property_types: property_types)
       end
 
       @values = [base_entity] + response_entities

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -9,7 +9,7 @@ module OData
                                                  property_types: {
                                                    ResponseSubmitDate: :datetime,
                                                    ResponseSubmitterName: :string,
-                                                   ResponseID: :string,
+                                                   ResponseID: :id,
                                                    ResponseShortcode: :string,
                                                    ResponseReviewed: :boolean,
                                                    FormName: :string

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -25,13 +25,13 @@ module OData
     end
 
     # Add an Entity for each of the parent's children,
-    # recursing into repeat groups.
+    # recursing into groups.
     def add_children(parent:, parent_name:, base_type: nil, root_name: nil, children: [])
-      repeat_number = 0
+      group_number = 0
       property_types = parent.c.map do |c|
         if c.is_a?(QingGroup)
-          repeat_number += 1
-          entity_name = get_entity_name(root_name, repeat_number, parent_name)
+          group_number += 1
+          entity_name = get_entity_name(root_name, group_number, parent_name)
           add_children(parent: c, parent_name: entity_name, children: children)
           child_name = "#{ODataController::NAMESPACE}.#{entity_name}"
           child_type = c.repeatable? ? "Collection(#{child_name})" : child_name
@@ -46,13 +46,13 @@ module OData
     end
 
     # Return the OData EntityType name for a group based on its nesting.
-    def get_entity_name(root_name, repeat_number, parent_name)
+    def get_entity_name(root_name, group_number, parent_name)
       if root_name
-        # The first level of repeats starts with the word "Repeat"
-        "Repeat.#{root_name}.R#{repeat_number}"
+        # The first level starts with the word "Group"
+        "Group.#{root_name}.G#{group_number}"
       else
-        # Each level of nesting after that is just one more `.R#` at the end.
-        "#{parent_name}.R#{repeat_number}"
+        # Each level of nesting after that is just one more `.G#` at the end.
+        "#{parent_name}.G#{group_number}"
       end
     end
   end

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -5,32 +5,25 @@ module OData
     attr_reader :values
 
     # TODO:
-    #      <EntityType Name="Response">
-    #         <Key>
-    #           <PropertyRef Name="ResponseID"/>
-    #         </Key>
-    #         <Property Name="ResponseSubmitDate" Type="Edm.DateTimeOffset"/>
-    #         <Property Name="ResponseSubmitterName" Type="Edm.String"/>
-    #         <Property Name="ResponseID" Type="Edm.String"/>
-    #         <Property Name="ResponseShortcode" Type="Edm.String"/>
-    #         <Property Name="ResponseReviewed" Type="Edm.Boolean"/>
-    #         <Property Name="FormName" Type="Edm.String"/>
-    #       </EntityType>
     #       <EntityType Name="Response.Form_A" BaseType="Demo.Response">
     #         <Property Name="FullName" Type="Edm.String"/>
     #         <Property Name="Age" Type="Edm.Int64"/>
     #       </EntityType>
     def initialize(distinct_forms)
       base_entity = SimpleEntity.new("Response", key_name: "ResponseID",
-                                                 properties: {
-                                                   ResponseID: SimpleProperty.new
+                                                 property_types: {
+                                                   ResponseSubmitDate: :datetime,
+                                                   ResponseSubmitterName: :string,
+                                                   ResponseID: :string,
+                                                   ResponseShortcode: :string,
+                                                   ResponseReviewed: :boolean,
+                                                   FormName: :string
                                                  })
       # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
       base_type = "#{ODataController::NAMESPACE}.Response"
       response_entities = distinct_forms.map do |form|
         SimpleEntity.new("Responses: #{form.name}", extra_tags: {BaseType: base_type},
-                                                    properties: {
-                                                      ID: SimpleProperty.new
+                                                    property_types: {
                                                     })
       end
 

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -20,7 +20,7 @@ module OData
       response_entities = distinct_forms.map do |form|
         build_nested_children(parent: form,
                               parent_name: "Responses: #{form.name}",
-                              base_type: "#{ODataController::NAMESPACE}.Response",
+                              base_type: "#{SimpleSchema::NAMESPACE}.Response",
                               root_name: form.name)
       end.flatten
 
@@ -47,7 +47,7 @@ module OData
     def child_qing_group(child, group_number:, parent_name:, root_name:, children:)
       entity_name = entity_name_for(root_name, group_number, parent_name)
       build_nested_children(parent: child, parent_name: entity_name, children: children)
-      child_name = "#{ODataController::NAMESPACE}.#{entity_name}"
+      child_name = "#{SimpleSchema::NAMESPACE}.#{entity_name}"
       child_type = child.repeatable? ? "Collection(#{child_name})" : child_name
       ["#{child.group_name} (#{group_number})", child_type]
     end

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -7,6 +7,9 @@ module OData
 
     # Property types are defined in odata_server's
     # `Property.column_adapter_return_types` static variable.
+    #
+    # TODO: Not all of these should be rendered as EntitySets (bottom of $metadata),
+    #   e.g. repeat groups should be excluded. This may not affect Power BI.
     def initialize(name, key_name: nil, property_types: {}, extra_tags: {})
       @name = name
       @plural_name = name

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -10,8 +10,7 @@ module OData
     def initialize(name, key_name: nil, property_types: {}, extra_tags: {})
       self.name = name
       self.plural_name = name
-      # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
-      self.qualified_name = "#{ODataController::NAMESPACE}.#{name}"
+      self.qualified_name = "#{SimpleSchema::NAMESPACE}.#{name}"
       self.key_property = key_name ? SimpleProperty.new(name: key_name) : nil
       self.properties = property_types.transform_values do |type|
         SimpleProperty.new(return_type: type)

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -5,12 +5,14 @@ module OData
     attr_reader :name, :plural_name, :qualified_name, :key_property, :properties, :navigation_properties,
       :extra_tags
 
-    def initialize(name, key_name: "ID", properties: {}, extra_tags: {})
+    # Property types are defined in odata_server's
+    # `Property.column_adapter_return_types` static variable.
+    def initialize(name, key_name: "ID", property_types: {}, extra_tags: {})
       @name = name
       @plural_name = name
       @qualified_name = name
       @key_property = SimpleProperty.new(name: key_name)
-      @properties = properties
+      @properties = property_types.transform_values { |type| SimpleProperty.new(return_type: type) }
       @navigation_properties = []
       @extra_tags = extra_tags
     end

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OData
+  class SimpleEntity
+    attr_reader :name, :plural_name, :qualified_name, :key_property, :properties, :navigation_properties
+
+    def initialize(name)
+      @name = name
+      @plural_name = name
+      @qualified_name = name
+      @key_property = SimpleProperty.new("Id")
+      @properties = {Shortcode: SimpleProperty.new("Shortcode")}
+      @navigation_properties = []
+    end
+  end
+end

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -4,18 +4,20 @@ module OData
   # Represents a single OData entity for our metadata.
   # This can be a top-level type (e.g. User) or a sub-type (e.g. a repeat group).
   class SimpleEntity
-    attr_reader :name, :plural_name, :qualified_name, :key_property, :properties,
+    attr_accessor :name, :plural_name, :qualified_name, :key_property, :properties,
       :navigation_properties, :extra_tags
 
     def initialize(name, key_name: nil, property_types: {}, extra_tags: {})
-      @name = name
-      @plural_name = name
+      self.name = name
+      self.plural_name = name
       # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
-      @qualified_name = "#{ODataController::NAMESPACE}.#{name}"
-      @key_property = key_name ? SimpleProperty.new(name: key_name) : nil
-      @properties = property_types.transform_values { |type| SimpleProperty.new(return_type: type) }
-      @navigation_properties = []
-      @extra_tags = extra_tags
+      self.qualified_name = "#{ODataController::NAMESPACE}.#{name}"
+      self.key_property = key_name ? SimpleProperty.new(name: key_name) : nil
+      self.properties = property_types.transform_values do |type|
+        SimpleProperty.new(return_type: type)
+      end
+      self.navigation_properties = []
+      self.extra_tags = extra_tags
     end
   end
 end

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -13,7 +13,7 @@ module OData
     def initialize(name, key_name: nil, property_types: {}, extra_tags: {})
       @name = name
       @plural_name = name
-      @qualified_name = name
+      @qualified_name = "#{ODataController::NAMESPACE}.#{name}"
       @key_property = key_name ? SimpleProperty.new(name: key_name) : nil
       @properties = property_types.transform_values { |type| SimpleProperty.new(return_type: type) }
       @navigation_properties = []

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -4,14 +4,13 @@ module OData
   # Represents a single OData entity for our metadata.
   # This can be a top-level type (e.g. User) or a sub-type (e.g. a repeat group).
   class SimpleEntity
-    attr_reader :name, :plural_name, :qualified_name, :key_property, :properties, :navigation_properties,
-      :extra_tags
+    attr_reader :name, :plural_name, :qualified_name, :key_property, :properties,
+      :navigation_properties, :extra_tags
 
-    # TODO: Not all of these should be rendered as EntitySets (bottom of $metadata),
-    #   e.g. repeat groups should be excluded. This may not affect Power BI.
     def initialize(name, key_name: nil, property_types: {}, extra_tags: {})
       @name = name
       @plural_name = name
+      # TODO: Fix `warning: toplevel constant NAMESPACE referenced by ODataController::NAMESPACE`
       @qualified_name = "#{ODataController::NAMESPACE}.#{name}"
       @key_property = key_name ? SimpleProperty.new(name: key_name) : nil
       @properties = property_types.transform_values { |type| SimpleProperty.new(return_type: type) }

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -2,15 +2,17 @@
 
 module OData
   class SimpleEntity
-    attr_reader :name, :plural_name, :qualified_name, :key_property, :properties, :navigation_properties
+    attr_reader :name, :plural_name, :qualified_name, :key_property, :properties, :navigation_properties,
+      :extra_tags
 
-    def initialize(name)
+    def initialize(name, key_name: "ID", properties: {}, extra_tags: {})
       @name = name
       @plural_name = name
       @qualified_name = name
-      @key_property = SimpleProperty.new("Id")
-      @properties = {Shortcode: SimpleProperty.new("Shortcode")}
+      @key_property = SimpleProperty.new(name: key_name)
+      @properties = properties
       @navigation_properties = []
+      @extra_tags = extra_tags
     end
   end
 end

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -7,11 +7,11 @@ module OData
 
     # Property types are defined in odata_server's
     # `Property.column_adapter_return_types` static variable.
-    def initialize(name, key_name: "ID", property_types: {}, extra_tags: {})
+    def initialize(name, key_name: nil, property_types: {}, extra_tags: {})
       @name = name
       @plural_name = name
       @qualified_name = name
-      @key_property = SimpleProperty.new(name: key_name)
+      @key_property = key_name ? SimpleProperty.new(name: key_name) : nil
       @properties = property_types.transform_values { |type| SimpleProperty.new(return_type: type) }
       @navigation_properties = []
       @extra_tags = extra_tags

--- a/app/models/o_data/simple_entity.rb
+++ b/app/models/o_data/simple_entity.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 module OData
+  # Represents a single OData entity for our metadata.
+  # This can be a top-level type (e.g. User) or a sub-type (e.g. a repeat group).
   class SimpleEntity
     attr_reader :name, :plural_name, :qualified_name, :key_property, :properties, :navigation_properties,
       :extra_tags
 
-    # Property types are defined in odata_server's
-    # `Property.column_adapter_return_types` static variable.
-    #
     # TODO: Not all of these should be rendered as EntitySets (bottom of $metadata),
     #   e.g. repeat groups should be excluded. This may not affect Power BI.
     def initialize(name, key_name: nil, property_types: {}, extra_tags: {})

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 module OData
+  # Represents a property of an OData entity for our metadata.
   class SimpleProperty
     attr_reader :name, :return_type
 
-    # Name is only needed for key_property.
+    # Note: Name is only needed for key_property.
+    # Note: Property types are defined in odata_server's
+    # `Property.column_adapter_return_types` static variable.
     def initialize(name: "", return_type: :text)
       @name = name
       @return_type = OData::ActiveRecordSchema::Property.column_adapter_return_types[return_type] || return_type

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -3,15 +3,15 @@
 module OData
   # Represents a property of an OData entity for our metadata.
   class SimpleProperty
-    attr_reader :name, :return_type
+    attr_accessor :name, :return_type
 
     # Note: Name is only needed for key_property.
     # Note: Property types are defined in odata_server's
     # `Property.column_adapter_return_types` static variable.
     def initialize(name: "", return_type: :text)
       return_types_map = OData::ActiveRecordSchema::Property.column_adapter_return_types
-      @name = name
-      @return_type = return_types_map[return_type] || return_type
+      self.name = name
+      self.return_type = return_types_map[return_type] || return_type
     end
 
     def nullable?

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -5,9 +5,9 @@ module OData
     attr_reader :name, :return_type
 
     # Name is only needed for key_property.
-    def initialize(name: "")
+    def initialize(name: "", return_type: :text)
       @name = name
-      @return_type = :text
+      @return_type = OData::ActiveRecordSchema::Property.column_adapter_return_types[return_type]
     end
 
     def nullable?

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module OData
+  class SimpleProperty
+    attr_reader :name, :return_type
+
+    def initialize(name)
+      @name = name
+      @return_type = :text
+    end
+
+    def nullable?
+      true
+    end
+  end
+end

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -4,7 +4,8 @@ module OData
   class SimpleProperty
     attr_reader :name, :return_type
 
-    def initialize(name)
+    # Name is only needed for key_property.
+    def initialize(name: "")
       @name = name
       @return_type = :text
     end

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -7,7 +7,7 @@ module OData
     # Name is only needed for key_property.
     def initialize(name: "", return_type: :text)
       @name = name
-      @return_type = OData::ActiveRecordSchema::Property.column_adapter_return_types[return_type]
+      @return_type = OData::ActiveRecordSchema::Property.column_adapter_return_types[return_type] || return_type
     end
 
     def nullable?

--- a/app/models/o_data/simple_property.rb
+++ b/app/models/o_data/simple_property.rb
@@ -9,8 +9,9 @@ module OData
     # Note: Property types are defined in odata_server's
     # `Property.column_adapter_return_types` static variable.
     def initialize(name: "", return_type: :text)
+      return_types_map = OData::ActiveRecordSchema::Property.column_adapter_return_types
       @name = name
-      @return_type = OData::ActiveRecordSchema::Property.column_adapter_return_types[return_type] || return_type
+      @return_type = return_types_map[return_type] || return_type
     end
 
     def nullable?

--- a/app/models/o_data/simple_schema.rb
+++ b/app/models/o_data/simple_schema.rb
@@ -5,11 +5,11 @@ module OData
   # when generating metadata. It's much simpler than the default and also
   # able to perform NEMO-specific logic.
   class SimpleSchema
-    attr_reader :namespace, :entity_types
+    attr_accessor :namespace, :entity_types
 
     def initialize(distinct_forms)
-      @namespace = "NEMO"
-      @entity_types = SimpleEntities.new(distinct_forms)
+      self.namespace = "NEMO"
+      self.entity_types = SimpleEntities.new(distinct_forms)
     end
   end
 end

--- a/app/models/o_data/simple_schema.rb
+++ b/app/models/o_data/simple_schema.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module OData
+  class SimpleSchema
+    attr_reader :namespace, :entity_types
+
+    def initialize
+      @namespace = "NEMO"
+      @entity_types = SimpleEntities.new
+    end
+  end
+end

--- a/app/models/o_data/simple_schema.rb
+++ b/app/models/o_data/simple_schema.rb
@@ -5,10 +5,12 @@ module OData
   # when generating metadata. It's much simpler than the default and also
   # able to perform NEMO-specific logic.
   class SimpleSchema
+    NAMESPACE = "NEMO"
+
     attr_accessor :namespace, :entity_types
 
     def initialize(distinct_forms)
-      self.namespace = "NEMO"
+      self.namespace = NAMESPACE
       self.entity_types = SimpleEntities.new(distinct_forms)
     end
   end

--- a/app/models/o_data/simple_schema.rb
+++ b/app/models/o_data/simple_schema.rb
@@ -4,9 +4,9 @@ module OData
   class SimpleSchema
     attr_reader :namespace, :entity_types
 
-    def initialize
+    def initialize(distinct_forms)
       @namespace = "NEMO"
-      @entity_types = SimpleEntities.new
+      @entity_types = SimpleEntities.new(distinct_forms)
     end
   end
 end

--- a/app/models/o_data/simple_schema.rb
+++ b/app/models/o_data/simple_schema.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module OData
+  # A schema for the odata_server engine that's used in place of the default
+  # when generating metadata. It's much simpler than the default and also
+  # able to perform NEMO-specific logic.
   class SimpleSchema
     attr_reader :namespace, :entity_types
 

--- a/app/models/question_type.rb
+++ b/app/models/question_type.rb
@@ -3,97 +3,79 @@
 class QuestionType
   AVAILABLE_PROPERTIES = %w[printable smsable textual headerable defaultable numeric
                             multimedia temporal has_options has_timezone refable reportable].freeze
-  attr_reader :name, :odk_name, :odata_type, :properties
+  attr_reader :name, :odk_name, :properties
 
   @attributes = [{
     name: "text",
     odk_name: "string",
-    odata_type: "string",
     properties: %w[printable smsable textual headerable defaultable refable reportable]
   }, {
     name: "long_text",
     odk_name: "string",
-    odata_type: "string",
     properties: %w[printable smsable textual refable defaultable reportable]
   }, {
     name: "barcode",
     odk_name: "barcode",
-    odata_type: "string",
     properties: %w[printable smsable textual refable reportable]
   }, {
     name: "integer",
     odk_name: "int",
-    odata_type: "integer",
     properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "counter",
     odk_name: "int",
-    odata_type: "integer",
     properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "decimal",
     odk_name: "decimal",
-    odata_type: "decimal",
     properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "location",
     odk_name: "geopoint",
-    odata_type: "string",
     properties: %w[reportable]
   }, {
     name: "select_one",
     odk_name: "select1",
-    odata_type: "string",
     properties: %w[printable has_options smsable headerable refable reportable]
   }, {
     name: "select_multiple",
     odk_name: "select",
-    odata_type: "string",
     properties: %w[printable has_options smsable headerable refable reportable]
   }, {
     name: "datetime",
     odk_name: "dateTime",
-    odata_type: "datetime",
     properties: %w[printable temporal has_timezone smsable headerable refable defaultable reportable]
   }, {
     name: "date",
     odk_name: "date",
-    odata_type: "date",
     properties: %w[printable temporal smsable headerable refable defaultable reportable]
   }, {
     name: "time",
     odk_name: "time",
-    odata_type: "time",
     properties: %w[printable temporal smsable headerable refable defaultable reportable]
   }, {
     name: "image",
     odk_name: "binary",
-    odata_type: "string",
     properties: %w[multimedia]
   }, {
     name: "annotated_image",
     odk_name: "binary",
-    odata_type: "string",
     properties: %w[multimedia]
   }, {
     name: "signature",
     odk_name: "binary",
-    odata_type: "string",
     properties: %w[multimedia printable]
   }, {
     name: "sketch",
     odk_name: "binary",
-    odata_type: "string",
     properties: %w[multimedia printable]
   }, {
     name: "audio",
     odk_name: "binary",
-    odata_type: "string",
     properties: %w[multimedia]
   }, {
     name: "video",
     odk_name: "binary",
-    odata_type: "string",
     properties: %w[multimedia]
   }]
 

--- a/app/models/question_type.rb
+++ b/app/models/question_type.rb
@@ -3,79 +3,97 @@
 class QuestionType
   AVAILABLE_PROPERTIES = %w[printable smsable textual headerable defaultable numeric
                             multimedia temporal has_options has_timezone refable reportable].freeze
-  attr_reader :name, :odk_name, :properties
+  attr_reader :name, :odk_name, :odata_type, :properties
 
   @attributes = [{
     name: "text",
     odk_name: "string",
+    odata_type: "string",
     properties: %w[printable smsable textual headerable defaultable refable reportable]
   }, {
     name: "long_text",
     odk_name: "string",
+    odata_type: "string",
     properties: %w[printable smsable textual refable defaultable reportable]
   }, {
     name: "barcode",
     odk_name: "barcode",
+    odata_type: "string",
     properties: %w[printable smsable textual refable reportable]
   }, {
     name: "integer",
     odk_name: "int",
+    odata_type: "integer",
     properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "counter",
     odk_name: "int",
+    odata_type: "integer",
     properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "decimal",
     odk_name: "decimal",
+    odata_type: "decimal",
     properties: %w[printable smsable numeric headerable refable defaultable reportable]
   }, {
     name: "location",
     odk_name: "geopoint",
+    odata_type: "string",
     properties: %w[reportable]
   }, {
     name: "select_one",
     odk_name: "select1",
+    odata_type: "string",
     properties: %w[printable has_options smsable headerable refable reportable]
   }, {
     name: "select_multiple",
     odk_name: "select",
+    odata_type: "string",
     properties: %w[printable has_options smsable headerable refable reportable]
   }, {
     name: "datetime",
     odk_name: "dateTime",
+    odata_type: "datetime",
     properties: %w[printable temporal has_timezone smsable headerable refable defaultable reportable]
   }, {
     name: "date",
     odk_name: "date",
+    odata_type: "date",
     properties: %w[printable temporal smsable headerable refable defaultable reportable]
   }, {
     name: "time",
     odk_name: "time",
+    odata_type: "time",
     properties: %w[printable temporal smsable headerable refable defaultable reportable]
   }, {
     name: "image",
     odk_name: "binary",
+    odata_type: "string",
     properties: %w[multimedia]
   }, {
     name: "annotated_image",
     odk_name: "binary",
+    odata_type: "string",
     properties: %w[multimedia]
   }, {
     name: "signature",
     odk_name: "binary",
+    odata_type: "string",
     properties: %w[multimedia printable]
   }, {
     name: "sketch",
     odk_name: "binary",
+    odata_type: "string",
     properties: %w[multimedia printable]
   }, {
     name: "audio",
     odk_name: "binary",
+    odata_type: "string",
     properties: %w[multimedia]
   }, {
     name: "video",
     odk_name: "binary",
+    odata_type: "string",
     properties: %w[multimedia]
   }]
 

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -5,19 +5,21 @@
 ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   before_action :refresh_schema
 
+  NAMESPACE = "NEMO"
+
   private
 
   # The odata engine expects a static schema, but our schema may change
   # whenever forms are updated and also depending on the current mission context.
   def refresh_schema
     schema = OData::ActiveRecordSchema::Base
-      .new("NEMO", skip_require: true,
-                   skip_add_entity_types: true,
-                   transformers: {
-                     root: ->(*args) { transform_json_for_root(*args) },
-                     metadata: ->(*args) { transform_schema_for_metadata(*args) },
-                     feed: ->(*args) { transform_json_for_resource_feed(*args) }
-                   })
+      .new(NAMESPACE, skip_require: true,
+                      skip_add_entity_types: true,
+                      transformers: {
+                        root: ->(*args) { transform_json_for_root(*args) },
+                        metadata: ->(*args) { transform_schema_for_metadata(*args) },
+                        feed: ->(*args) { transform_json_for_resource_feed(*args) }
+                      })
 
     add_entity_types(schema, distinct_forms)
 

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -3,11 +3,13 @@
 # Here we re-open odata_server's main controller
 # to add NEMO things like before_action.
 ODataController.class_eval do # rubocop:disable Metrics/BlockLength
-  before_action :refresh_schema
-
   NAMESPACE = "NEMO"
 
   private
+
+  def before_action
+    refresh_schema
+  end
 
   # The odata engine expects a static schema, but our schema may change
   # whenever forms are updated and also depending on the current mission context.

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -3,8 +3,6 @@
 # Here we re-open odata_server's main controller
 # to add NEMO things like before_action.
 ODataController.class_eval do # rubocop:disable Metrics/BlockLength
-  NAMESPACE = "NEMO"
-
   private
 
   def before_action
@@ -14,8 +12,9 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   # The odata engine expects a static schema, but our schema may change
   # whenever forms are updated and also depending on the current mission context.
   def refresh_schema
+    namespace = OData::SimpleSchema::NAMESPACE
     schema = OData::ActiveRecordSchema::Base
-      .new(NAMESPACE, skip_require: true,
+      .new(namespace, skip_require: true,
                       skip_add_entity_types: true,
                       transformers: {
                         root: ->(*args) { transform_json_for_root(*args) },

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -62,6 +62,7 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
     name = "Responses: #{name}"
     entity = schema.add_entity_type(Response, where: {form_id: id},
                                               name: name,
+                                              url_name: "Responses-#{id}",
                                               reflect_on_associations: false)
 
     # We don't want to double-pluralize since it already says "Responses",

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -3,7 +3,7 @@
 # Here we re-open odata_server's main controller
 # to add NEMO things like before_action.
 ODataController.class_eval do # rubocop:disable Metrics/BlockLength
-  private
+  private # rubocop:disable Layout/EmptyLinesAroundAccessModifier
 
   def before_action
     refresh_schema

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -30,8 +30,8 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
     json
   end
 
-  def transform_schema_for_metadata(schema)
-    schema
+  def transform_schema_for_metadata(_schema)
+    OData::SimpleSchema.new
   end
 
   def transform_json_for_resource_feed(json)

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -5,6 +5,8 @@
 ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   before_action :refresh_schema
 
+  private
+
   # The odata engine expects a static schema, but our schema may change
   # whenever forms are updated and also depending on the current mission context.
   def refresh_schema
@@ -17,7 +19,7 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
                      feed: ->(*args) { transform_json_for_resource_feed(*args) }
                    })
 
-    add_entity_types(schema)
+    add_entity_types(schema, distinct_forms)
 
     ODataController.data_services.clear_schemas
     ODataController.data_services.append_schemas([schema])
@@ -31,23 +33,24 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   end
 
   def transform_schema_for_metadata(_schema)
-    OData::SimpleSchema.new
+    OData::SimpleSchema.new(distinct_forms)
   end
 
   def transform_json_for_resource_feed(json)
     json
   end
 
-  # Manually add our entity types, grouping responses by form.
-  def add_entity_types(schema)
-    forms = Form
+  def distinct_forms
+    Form
       .live
       .where(mission: current_mission)
       .distinct
       .order(:name)
-      .pluck(:id, :name)
+  end
 
-    forms.each { |id, name| add_form_entity_type(schema, id, name) }
+  # Manually add our entity types, grouping responses by form.
+  def add_entity_types(schema, distinct_forms)
+    distinct_forms.each { |form| add_form_entity_type(schema, form.id, form.name) }
   end
 
   # Add an entity type to the schema for a given form.

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -41,6 +41,8 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   end
 
   def transform_json_for_resource_feed(json)
+    # TODO: Use Tom's code here
+    json[:value] = []
     json
   end
 

--- a/spec/features/forms/form/printable_spec.rb
+++ b/spec/features/forms/form/printable_spec.rb
@@ -10,7 +10,7 @@ feature "forms", js: true do
   let(:forms_path) { "/en/m/#{form.mission.compact_name}/forms" }
 
   # Allow longer delays because specs were failing on Travis.
-  let(:longer_wait_time) { 20 }
+  let(:longer_wait_time) { 120 }
 
   before do
     login(user)

--- a/spec/fixtures/odata/basic_metadata.xml
+++ b/spec/fixtures/odata/basic_metadata.xml
@@ -14,12 +14,12 @@
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
-        <Property Name="Integer Question Title 1" Type="Edm.Int64" Nullable="true"/>
-        <Property Name="Select One Question Title 2" Type="Edm.String" Nullable="true"/>
-        <Property Name="Text Question Title 3" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name1*" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="*q_name2*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name3*" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form2*" BaseType="NEMO.Response">
-        <Property Name="Text Question Title 4" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name4*" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityContainer Name="NEMOService">
         <EntitySet Name="Response" EntityType="NEMO.Response">

--- a/spec/fixtures/odata/basic_metadata.xml
+++ b/spec/fixtures/odata/basic_metadata.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="NEMO" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Response">
+        <Key>
+          <PropertyRef Name="ResponseID"/>
+        </Key>
+        <Property Name="ResponseSubmitDate" Type="Edm.DateTimeOffset" Nullable="true"/>
+        <Property Name="ResponseSubmitterName" Type="Edm.String" Nullable="true"/>
+        <Property Name="ResponseID" Type="Edm.Guid" Nullable="true"/>
+        <Property Name="ResponseShortcode" Type="Edm.String" Nullable="true"/>
+        <Property Name="ResponseReviewed" Type="Edm.Boolean" Nullable="true"/>
+        <Property Name="FormName" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
+        <Property Name="Integer Question Title 1" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="Select One Question Title 2" Type="Edm.String" Nullable="true"/>
+        <Property Name="Text Question Title 3" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityType Name="Responses: *form2*" BaseType="NEMO.Response">
+        <Property Name="Text Question Title 4" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityContainer Name="NEMOService">
+        <EntitySet Name="Response" EntityType="NEMO.Response">
+        </EntitySet>
+        <EntitySet Name="Responses: *form1*" EntityType="NEMO.Responses: *form1*">
+        </EntitySet>
+        <EntitySet Name="Responses: *form2*" EntityType="NEMO.Responses: *form2*">
+        </EntitySet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/spec/fixtures/odata/empty_metadata.xml
+++ b/spec/fixtures/odata/empty_metadata.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="NEMO" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Response">
+        <Key>
+          <PropertyRef Name="ResponseID"/>
+        </Key>
+        <Property Name="ResponseSubmitDate" Type="Edm.DateTimeOffset" Nullable="true"/>
+        <Property Name="ResponseSubmitterName" Type="Edm.String" Nullable="true"/>
+        <Property Name="ResponseID" Type="Edm.Guid" Nullable="true"/>
+        <Property Name="ResponseShortcode" Type="Edm.String" Nullable="true"/>
+        <Property Name="ResponseReviewed" Type="Edm.Boolean" Nullable="true"/>
+        <Property Name="FormName" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityContainer Name="NEMOService">
+        <EntitySet Name="Response" EntityType="NEMO.Response">
+        </EntitySet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/spec/fixtures/odata/nested_groups_metadata.xml
+++ b/spec/fixtures/odata/nested_groups_metadata.xml
@@ -8,7 +8,7 @@
       </EntityType>
       <EntityType Name="Group.*form1*.G2">
         <Property Name="*q_name4*" Type="Edm.String" Nullable="true"/>
-        <Property Name="Group Name (1)" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
+        <Property Name="*group_name1*" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
       </EntityType>
       <EntityType Name="Group.*form1*.G2.G1">
         <Property Name="*q_name5*" Type="Edm.Int64" Nullable="true"/>
@@ -27,8 +27,8 @@
       </EntityType>
       <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
         <Property Name="*q_name1*" Type="Edm.String" Nullable="true"/>
-        <Property Name="Group Name (1)" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
-        <Property Name="Group Name (2)" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
+        <Property Name="*group_name2*" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
+        <Property Name="*group_name3*" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
       </EntityType>
       <EntityContainer Name="NEMOService">
         <EntitySet Name="Group.*form1*.G1" EntityType="NEMO.Group.*form1*.G1">

--- a/spec/fixtures/odata/nested_groups_metadata.xml
+++ b/spec/fixtures/odata/nested_groups_metadata.xml
@@ -3,16 +3,16 @@
   <edmx:DataServices>
     <Schema Namespace="NEMO" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityType Name="Group.*form1*.G1">
-        <Property Name="Text Question Title 2" Type="Edm.String" Nullable="true"/>
-        <Property Name="Integer Question Title 3" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="*q_name2*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name3*" Type="Edm.Int64" Nullable="true"/>
       </EntityType>
       <EntityType Name="Group.*form1*.G2">
-        <Property Name="Text Question Title 4" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name4*" Type="Edm.String" Nullable="true"/>
         <Property Name="Group Name (1)" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
       </EntityType>
       <EntityType Name="Group.*form1*.G2.G1">
-        <Property Name="Integer Question Title 5" Type="Edm.Int64" Nullable="true"/>
-        <Property Name="Text Question Title 6" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name5*" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="*q_name6*" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Response">
         <Key>
@@ -26,7 +26,7 @@
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
-        <Property Name="Text Question Title 1" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_name1*" Type="Edm.String" Nullable="true"/>
         <Property Name="Group Name (1)" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
         <Property Name="Group Name (2)" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
       </EntityType>

--- a/spec/fixtures/odata/nested_groups_metadata.xml
+++ b/spec/fixtures/odata/nested_groups_metadata.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="NEMO" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Group.*form1*.G1">
+        <Property Name="Text Question Title 2" Type="Edm.String" Nullable="true"/>
+        <Property Name="Integer Question Title 3" Type="Edm.Int64" Nullable="true"/>
+      </EntityType>
+      <EntityType Name="Group.*form1*.G2">
+        <Property Name="Text Question Title 4" Type="Edm.String" Nullable="true"/>
+        <Property Name="Group Name (1)" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
+      </EntityType>
+      <EntityType Name="Group.*form1*.G2.G1">
+        <Property Name="Integer Question Title 5" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="Text Question Title 6" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityType Name="Response">
+        <Key>
+          <PropertyRef Name="ResponseID"/>
+        </Key>
+        <Property Name="ResponseSubmitDate" Type="Edm.DateTimeOffset" Nullable="true"/>
+        <Property Name="ResponseSubmitterName" Type="Edm.String" Nullable="true"/>
+        <Property Name="ResponseID" Type="Edm.Guid" Nullable="true"/>
+        <Property Name="ResponseShortcode" Type="Edm.String" Nullable="true"/>
+        <Property Name="ResponseReviewed" Type="Edm.Boolean" Nullable="true"/>
+        <Property Name="FormName" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
+        <Property Name="Text Question Title 1" Type="Edm.String" Nullable="true"/>
+        <Property Name="Group Name (1)" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
+        <Property Name="Group Name (2)" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
+      </EntityType>
+      <EntityContainer Name="NEMOService">
+        <EntitySet Name="Group.*form1*.G1" EntityType="NEMO.Group.*form1*.G1">
+        </EntitySet>
+        <EntitySet Name="Group.*form1*.G2" EntityType="NEMO.Group.*form1*.G2">
+        </EntitySet>
+        <EntitySet Name="Group.*form1*.G2.G1" EntityType="NEMO.Group.*form1*.G2.G1">
+        </EntitySet>
+        <EntitySet Name="Response" EntityType="NEMO.Response">
+        </EntitySet>
+        <EntitySet Name="Responses: *form1*" EntityType="NEMO.Responses: *form1*">
+        </EntitySet>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/spec/requests/api/v1/answers_request_spec.rb
+++ b/spec/requests/api/v1/answers_request_spec.rb
@@ -6,7 +6,7 @@ describe "answers API requests" do
   include_context "api"
 
   describe "list answers by form" do
-    include_context "api_form_with_responses"
+    include_context "api form with responses"
 
     it "should return appropriate json sorted newest first" do
       get "/api/v1/m/mission1/answers?form_id=#{@form.id}&question_id=#{@form.questions[0].id}",

--- a/spec/requests/api/v1/responses_request_spec.rb
+++ b/spec/requests/api/v1/responses_request_spec.rb
@@ -6,7 +6,7 @@ describe "response API requests" do
   include_context "api"
 
   describe "list responses by form" do
-    include_context "api_form_with_responses"
+    include_context "api form with responses"
 
     it "should return appropriate json sorted newest first" do
       get "/api/v1/m/mission1/responses?form_id=#{@form.id}", headers: headers

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -17,7 +17,7 @@ describe "$metadata" do
     include_context "odata_with_basic_forms"
 
     it "renders as expected" do
-      expect_output_fixture("basic_metadata.xml", form: [form.name, form_with_no_responses.name])
+      expect_output_fixture("basic_metadata.xml", forms: [form, form_with_no_responses])
     end
   end
 
@@ -25,7 +25,7 @@ describe "$metadata" do
     include_context "odata_with_nested_groups"
 
     it "renders as expected" do
-      expect_output_fixture("nested_groups_metadata.xml", form: [form.name])
+      expect_output_fixture("nested_groups_metadata.xml", forms: [form])
     end
   end
 end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -8,24 +8,16 @@ describe "$metadata" do
   let(:path) { "#{mission_api_route}/$metadata" }
 
   context "with no forms" do
-    it "renders as expected" do
-      expect_output_fixture("empty_metadata.xml")
-    end
+    it { expect_output_fixture("empty_metadata.xml") }
   end
 
   context "with several basic forms" do
-    include_context "odata_with_basic_forms"
-
-    it "renders as expected" do
-      expect_output_fixture("basic_metadata.xml", forms: [form, form_with_no_responses])
-    end
+    include_context "odata with basic forms"
+    it { expect_output_fixture("basic_metadata.xml", forms: [form, form_with_no_responses]) }
   end
 
   context "with nested groups" do
-    include_context "odata_with_nested_groups"
-
-    it "renders as expected" do
-      expect_output_fixture("nested_groups_metadata.xml", forms: [form])
-    end
+    include_context "odata with nested groups"
+    it { expect_output_fixture("nested_groups_metadata.xml", forms: [form]) }
   end
 end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "root json" do
+  include_context "odata"
+
+  let(:path) { "#{mission_api_route}/$metadata" }
+
+  context "with no forms" do
+    it "renders as expected" do
+      expect_output_fixture("empty_metadata.xml")
+    end
+  end
+
+  context "with several basic forms" do
+    include_context "odata_with_basic_forms"
+
+    it "renders as expected" do
+      expect_output_fixture("basic_metadata.xml", form: [form.name, form_with_no_responses.name])
+    end
+  end
+end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "root json" do
+describe "$metadata" do
   include_context "odata"
 
   let(:path) { "#{mission_api_route}/$metadata" }
@@ -18,6 +18,14 @@ describe "root json" do
 
     it "renders as expected" do
       expect_output_fixture("basic_metadata.xml", form: [form.name, form_with_no_responses.name])
+    end
+  end
+
+  context "with nested groups" do
+    include_context "odata_with_nested_groups"
+
+    it "renders as expected" do
+      expect_output_fixture("nested_groups_metadata.xml", form: [form.name])
     end
   end
 end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -18,6 +18,10 @@ describe "$metadata" do
 
   context "with nested groups" do
     include_context "odata with nested groups"
-    it { expect_output_fixture("nested_groups_metadata.xml", forms: [form]) }
+    it do
+      # TODO: These names will be generated differently in an upcoming commit.
+      substitutions = {group_name: ["Group Name (1)", "Group Name (1)", "Group Name (2)"]}
+      expect_output_fixture("nested_groups_metadata.xml", forms: [form], substitutions: substitutions)
+    end
   end
 end

--- a/spec/requests/odata/root_json_spec.rb
+++ b/spec/requests/odata/root_json_spec.rb
@@ -16,17 +16,17 @@ describe "root json" do
     end
   end
 
-  context "with several forms" do
+  context "with basic forms" do
     include_context "odata_with_basic_forms"
 
     it "renders as expected" do
-      entity_1_name = "Responses: #{form.name}"
-      entity_2_name = "Responses: #{form_with_no_responses.name}"
+      names = ["Responses: #{form.name}", "Responses: #{form_with_no_responses.name}"]
+      urls = %W[Responses-#{form.id} Responses-#{form_with_no_responses.id}]
       expect_output({
         "@odata.context": "http://www.example.com/en/m/#{get_mission.compact_name}/odata/v1/$metadata",
         value: [
-          {name: entity_1_name, kind: "EntitySet", url: entity_1_name},
-          {name: entity_2_name, kind: "EntitySet", url: entity_2_name}
+          {name: names[0], kind: "EntitySet", url: urls[0]},
+          {name: names[1], kind: "EntitySet", url: urls[1]}
         ]
       }.to_json)
     end

--- a/spec/requests/odata/root_json_spec.rb
+++ b/spec/requests/odata/root_json_spec.rb
@@ -17,7 +17,7 @@ describe "root json" do
   end
 
   context "with several forms" do
-    include_context "odata_with_forms"
+    include_context "odata_with_basic_forms"
 
     it "renders as expected" do
       entity_1_name = "Responses: #{form.name}"

--- a/spec/requests/odata/root_json_spec.rb
+++ b/spec/requests/odata/root_json_spec.rb
@@ -17,7 +17,7 @@ describe "root json" do
   end
 
   context "with basic forms" do
-    include_context "odata_with_basic_forms"
+    include_context "odata with basic forms"
 
     it "renders as expected" do
       names = ["Responses: #{form.name}", "Responses: #{form_with_no_responses.name}"]

--- a/spec/support/contexts/api_context.rb
+++ b/spec/support/contexts/api_context.rb
@@ -10,7 +10,7 @@ shared_context "api" do
   let(:json) { JSON.parse(response.body) }
 end
 
-shared_context "api_form_with_responses" do
+shared_context "api form with responses" do
   before do
     decoy = create(:form, mission: mission, access_level: "public", question_types: %w[integer])
     create(:response, form: decoy, answer_values: [1])

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -21,10 +21,13 @@ shared_context "odata" do
     expect(response.body.rstrip).to eq(expected.rstrip)
   end
 
-  def expect_output_fixture(filename, substitutions = {})
+  def expect_output_fixture(filename, forms: [])
+    form_names = forms.map(&:name)
+    form_q_names = forms.map(&:questionings).flatten.map(&:name)
     get(path)
     expect(response).to have_http_status(:ok)
-    expect(response.body).to eq(prepare_fixture("odata/#{filename}", substitutions))
+    expect(response.body).to eq(prepare_fixture("odata/#{filename}", form: form_names,
+                                                                     q_name: form_q_names))
   end
 end
 

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -20,9 +20,15 @@ shared_context "odata" do
     # Don't worry about trailing newlines.
     expect(response.body.rstrip).to eq(expected.rstrip)
   end
+
+  def expect_output_fixture(filename, substitutions = {})
+    get(path)
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq(prepare_fixture("odata/#{filename}", substitutions))
+  end
 end
 
-shared_context "odata_with_forms" do
+shared_context "odata_with_basic_forms" do
   let!(:form) { create(:form, :live, question_types: %w[integer select_one text]) }
   let!(:form_with_no_responses) { create(:form, :live, question_types: %w[text]) }
   let(:unpublished_form) { create(:form, question_types: %w[text]) }

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -56,7 +56,7 @@ shared_context "odata_with_nested_groups" do
 
   before do
     Timecop.freeze(Time.now.utc - 10.days) do
-      create(:response, form: form, answer_values: ["A", ["B", 10], ["D", [21, "E1"], [22, "E2"]]])
+      create(:response, form: form, answer_values: [%w[A B], ["C", 10], ["D", [21, "E1"]]])
     end
     Timecop.freeze(Time.now.utc - 5.days) do
       create(:response, form: form, answer_values: [])

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -31,7 +31,7 @@ shared_context "odata" do
   end
 end
 
-shared_context "odata_with_basic_forms" do
+shared_context "odata with basic forms" do
   let!(:form) { create(:form, :live, question_types: %w[integer select_one text]) }
   let!(:form_with_no_responses) { create(:form, :live, question_types: %w[text]) }
   let(:unpublished_form) { create(:form, question_types: %w[text]) }
@@ -51,7 +51,7 @@ shared_context "odata_with_basic_forms" do
   end
 end
 
-shared_context "odata_with_nested_groups" do
+shared_context "odata with nested groups" do
   let!(:form) { create(:form, :live, question_types: ["text", %w[text integer], ["text", %w[integer text]]]) }
 
   before do

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -21,13 +21,14 @@ shared_context "odata" do
     expect(response.body.rstrip).to eq(expected.rstrip)
   end
 
-  def expect_output_fixture(filename, forms: [])
+  def expect_output_fixture(filename, forms: [], substitutions: {})
     form_names = forms.map(&:name)
     form_q_names = forms.map(&:questionings).flatten.map(&:name)
     get(path)
     expect(response).to have_http_status(:ok)
     expect(response.body).to eq(prepare_fixture("odata/#{filename}", form: form_names,
-                                                                     q_name: form_q_names))
+                                                                     q_name: form_q_names,
+                                                                     **substitutions))
   end
 end
 

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -47,3 +47,16 @@ shared_context "odata_with_basic_forms" do
     create(:response, mission: other_mission, form: other_form, answer_values: ["X"])
   end
 end
+
+shared_context "odata_with_nested_groups" do
+  let!(:form) { create(:form, :live, question_types: ["text", %w[text integer], ["text", %w[integer text]]]) }
+
+  before do
+    Timecop.freeze(Time.now.utc - 10.days) do
+      create(:response, form: form, answer_values: ["A", ["B", 10], ["D", [21, "E1"], [22, "E2"]]])
+    end
+    Timecop.freeze(Time.now.utc - 5.days) do
+      create(:response, form: form, answer_values: [])
+    end
+  end
+end


### PR DESCRIPTION
Companion PR: https://github.com/sassafrastech/odata_server/pull/4

### Changes

- Override the `/$metadata` schema with our own (much simpler) classes that properly define our hierarchy of nestable groups
- Move `before_action` to the very first action (because later actions depend on the schema already existing)
- Temporarily stub out the resource JSON (awaiting the upcoming PR for 10595), since incorrect data types can break Power BI

### Examples

As a result of this PR:
- http://nemo.test/en/m/sandbox/odata/v1/
    - Now has URL-friendly names like `Responses-7e058345-4526-4ba8-b3ad-2cbf5e49a2b5`
        - Old names broke Power BI if they contained colons
- http://nemo.test/en/m/sandbox/odata/v1/$metadata
    - Now defines EntityTypes for all groups
    - Now specifies accurate types for answer values
- http://nemo.test/en/m/sandbox/odata/v1/Responses-aabe13be-bc6e-4b03-b2a4-1a2b9c9f41b2
    - New URL path works, and data is stubbed
