### PR TITLE
Explicitly require eventmachine (for homebrew)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "dalli", "~> 2.7.4" # memcache
 gem "delayed_job_active_record", "~> 4.1.3"
 gem "descriptive_statistics", "~> 2.5.1", require: "descriptive_statistics/safe" # mean, median, etc.
 gem "draper", "~> 3.0.1"
+gem "eventmachine", "~> 1.2", platform: :ruby
 gem "exception_notification", "~> 4.2"
 gem "fog-aws", "~> 3.3.0"
 gem "friendly_id", "~> 5.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -607,6 +607,7 @@ DEPENDENCIES
   draper (~> 3.0.1)
   draper-cancancan (~> 1.1)
   dropzonejs-rails (~> 0.7.3)
+  eventmachine (~> 1.2)
   exception_notification (~> 4.2)
   factory_girl_rails (~> 4.5.0)
   faker (~> 1.6)

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,10 @@ require File.expand_path("boot", __dir__)
 require "rails/all"
 require "coffee_script"
 
+# This may be required on Mac with Homebrew.
+# https://github.com/oneclick/rubyinstaller2/issues/96#issuecomment-548249647
+require "em/pure_ruby" unless defined?(EventMachine)
+
 Bundler.require(*Rails.groups)
 
 module ELMO


### PR DESCRIPTION
Fixes:

```
Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'
nemo/vendor/bundle/ruby/2.4.0/gems/activesupport-5.2.4.2/lib/active_support/dependencies.rb:291:in `require': dlopen(nemo/vendor/bundle/ruby/2.4.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle, 9): Library not loaded: /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib (LoadError)
  Referenced from: nemo/vendor/bundle/ruby/2.4.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle
  Reason: image not found - nemo/vendor/bundle/ruby/2.4.0/gems/eventmachine-1.2.7/lib/rubyeventmachine.bundle
```

I tried quite a few other suggested workarounds to no avail; this comment did it for me https://github.com/oneclick/rubyinstaller2/issues/96#issuecomment-548249647