### PR TITLE
10595 OData resources + cached json

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -60,9 +60,7 @@ class Answer < ResponseNode
   attr_accessor :location_values_replicated
   alias questioning form_item
 
-  belongs_to :option_node, inverse_of: :answers
   belongs_to :response, inverse_of: :answers, touch: true
-  has_many :choices, -> { order(:created_at) }, dependent: :destroy, inverse_of: :answer, autosave: true
   has_one :media_object, dependent: :destroy, inverse_of: :answer, autosave: true, class_name: "Media::Object"
 
   before_validation :replicate_location_values
@@ -85,7 +83,7 @@ class Answer < ResponseNode
   delegate :question, :qtype, :qtype_name, :required?, :visible?, :enabled?, :multimedia?,
     :option_set, :option_set_id, :options, :first_level_option_nodes, :condition,
     :parent_group_name, to: :questioning
-  delegate :name, to: :question, prefix: true
+  delegate :name, :code, to: :question, prefix: true
   delegate :name, to: :level, prefix: true, allow_nil: true
   delegate :name, to: :option_node, prefix: true, allow_nil: true
   delegate :mission, to: :response

--- a/app/models/answer_group.rb
+++ b/app/models/answer_group.rb
@@ -49,7 +49,7 @@
 # Its children can be Answers, AnswerSets, AnswerGroups, or AnswerGroupSets.
 class AnswerGroup < ResponseNode
   alias qing_group form_item
-  delegate :group_hint, to: :form_item
+  delegate :group_name, :group_hint, to: :form_item
 
   def repeatable?
     parent.is_a?(AnswerGroupSet)

--- a/app/models/answer_group_set.rb
+++ b/app/models/answer_group_set.rb
@@ -49,6 +49,7 @@
 # Its children are AnswerGroups.
 class AnswerGroupSet < ResponseNode
   alias qing_group form_item
+  delegate :group_name, :group_hint, to: :form_item
 
   def name
     qing_group.group_name

--- a/app/models/answer_set.rb
+++ b/app/models/answer_set.rb
@@ -62,6 +62,10 @@ class AnswerSet < ResponseNode
     answers.any?(&:invalid?)
   end
 
+  def question_code
+    questioning.code
+  end
+
   private
 
   # Returns the non-nil answer with the lowest rank. May return nil if the set is blank.

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -49,7 +49,7 @@ module OData
       build_nested_children(parent: child, parent_name: entity_name, children: children)
       child_name = "#{SimpleSchema::NAMESPACE}.#{entity_name}"
       child_type = child.repeatable? ? "Collection(#{child_name})" : child_name
-      # TODO: Remove `(group_number)` once we use unique group_code in an upcoming commit.
+      # TODO: Remove `(group_number)` once we enforce unique group_codes.
       ["#{child.code.vanilla} (#{group_number})", child_type]
     end
 

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -45,17 +45,17 @@ module OData
     end
 
     def child_qing_group(child, group_number:, parent_name:, root_name:, children:)
-      entity_name = entity_name_for(root_name, group_number, parent_name)
+      entity_name = entity_name_for(root_name, group_number, parent_name).vanilla
       build_nested_children(parent: child, parent_name: entity_name, children: children)
       child_name = "#{SimpleSchema::NAMESPACE}.#{entity_name}"
       child_type = child.repeatable? ? "Collection(#{child_name})" : child_name
       # TODO: Remove `(group_number)` once we use unique group_code in an upcoming commit.
-      ["#{child.group_name} (#{group_number})", child_type]
+      ["#{child.code.vanilla} (#{group_number})", child_type]
     end
 
     def child_qing(child)
       qtype = OData::QuestionType.new(child.qtype)
-      [child.name, qtype.odata_type]
+      [child.code.vanilla, qtype.odata_type]
     end
 
     # Return the OData EntityType name for a group based on its nesting.

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -49,8 +49,7 @@ module OData
       build_nested_children(parent: child, parent_name: entity_name, children: children)
       child_name = "#{SimpleSchema::NAMESPACE}.#{entity_name}"
       child_type = child.repeatable? ? "Collection(#{child_name})" : child_name
-      # TODO: Remove `(group_number)` once we enforce unique group_codes.
-      ["#{child.code.vanilla} (#{group_number})", child_type]
+      [child.code.vanilla, child_type]
     end
 
     def child_qing(child)

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -6,6 +6,7 @@
 # Table name: responses
 #
 #  id                   :uuid             not null, primary key
+#  cached_json          :jsonb
 #  checked_out_at       :datetime
 #  incomplete           :boolean          default(FALSE), not null
 #  odk_hash             :string(255)

--- a/app/models/response_node.rb
+++ b/app/models/response_node.rb
@@ -53,6 +53,11 @@ class ResponseNode < ApplicationRecord
   belongs_to :form_item, inverse_of: :response_nodes, foreign_key: "questioning_id"
   belongs_to :response
 
+  # Used only for Answer, but included here for eager loading.
+  belongs_to :option_node, inverse_of: :answers
+  has_many :choices, -> { order(:created_at) }, foreign_key: :answer_id, dependent: :destroy,
+                                                inverse_of: :answer, autosave: true
+
   # We don't use the advisory lock for now because it slows down concurrent inserts a lot and doesn't
   # seem necessary since we don't do a lot of concurrent edits.
   has_closure_tree order: "new_rank", numeric_order: true, dont_order_roots: true,

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -20,7 +20,7 @@ module Results
       object["ResponseSubmitDate"] = response.created_at.iso8601
       object["ResponseReviewed"] = response.reviewed?
       root = response.root_node_including_tree(:choices, form_item: :question, option_node: :option_set)
-      add_answers(root, object)
+      add_answers(root, object) unless root.nil?
       # Make sure we include everything from the metadata in our response,
       # even if the Response didn't include that answer.
       response.form.c.map do |c|
@@ -65,8 +65,8 @@ module Results
     def value_for(answer)
       case answer.qtype_name
       when "date" then answer.date_value
-      when "time" then answer.time_value.to_s(:std_time)
-      when "datetime" then answer.datetime_value.iso8601
+      when "time" then answer.time_value&.to_s(:std_time)
+      when "datetime" then answer.datetime_value&.iso8601
       when "integer", "counter" then answer.value&.to_i
       when "decimal" then answer.value&.to_f
       when "select_one" then answer.option_name
@@ -76,7 +76,7 @@ module Results
         value = answer.value.presence
         # TODO: Is this parsing something we want to do? Is there already a conventional way?
         #   Output is SUPER GROSS without it because of copy/paste from MS Word.
-        value&.match(/\A<!--/) ? simple_format(value) : value.to_s
+        value&.match(/\A<!--/) ? simple_format(value) : value&.to_s
       end
     end
 

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Results
+  # Generates cached JSON for a given response.
+  class ResponseJsonGenerator
+    attr_accessor :response
+
+    def initialize(response)
+      self.response = response
+    end
+
+    def as_json
+      object = {}
+      object["ResponseID"] = response.id
+      object["ResponseShortcode"] = response.shortcode
+      object["FormName"] = form.name
+      object["ResponseSubmitterName"] = user.name
+      object["ResponseSubmitDate"] = response.created_at.iso8601
+      object["ResponseReviewed"] = response.reviewed?
+      root = response.root_node_including_tree(:choices, form_item: :question, option_node: :option_set)
+      add_answers(root, object)
+      object
+    end
+
+    private
+
+    delegate :form, :user, to: :response
+
+    def add_answers(node, object)
+      node.children.each do |child_node|
+        if child_node.is_a?(Answer)
+          object[child_node.question_code] = value_for(child_node)
+        elsif child_node.is_a?(AnswerSet)
+          object[child_node.question_code] = answer_set_value(child_node)
+        elsif child_node.is_a?(AnswerGroup) && !child_node.repeatable?
+          add_answers(child_node, object)
+        end
+      end
+    end
+
+    def answer_set_value(answer_set)
+      set = {}
+      answer_set.children.each do |answer|
+        option_node = answer.option_node
+        set[option_node.level_name] = answer.option_name
+      end
+      set
+    end
+
+    def value_for(answer)
+      case answer.qtype_name
+      when "date" then answer.date_value
+      when "time" then answer.time_value.to_s(:std_time)
+      when "datetime" then answer.datetime_value.iso8601
+      when "integer", "counter" then answer.value&.to_i
+      when "decimal" then answer.value&.to_f
+      when "select_one" then answer.option_name
+      when "select_multiple" then answer.choices.empty? ? nil : answer.choices.map(&:option_name).sort
+      when "location" then answer.attributes.slice(*%w[latitude longitude altitude accuracy])
+      else answer.value.presence
+      end
+    end
+  end
+end

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -33,7 +33,7 @@ module Results
         elsif child_node.is_a?(AnswerSet)
           object[child_node.question_code] = answer_set_value(child_node)
         elsif child_node.is_a?(AnswerGroup) && !child_node.repeatable?
-          add_answers(child_node, object)
+          add_answers(child_node, object[child_node.group_name.gsub(/[^a-z0-9]/i, "")] = {})
         end
       end
     end

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -71,7 +71,7 @@ module Results
       when "decimal" then answer.value&.to_f
       when "select_one" then answer.option_name
       when "select_multiple" then answer.choices.empty? ? nil : answer.choices.map(&:option_name).sort.to_s
-      when "location" then answer.attributes.slice(*%w[latitude longitude altitude accuracy]).to_s
+      when "location" then answer.attributes.slice("latitude", "longitude", "altitude", "accuracy").to_s
       else
         value = answer.value.presence
         # Data that's been copied from MS Word contains a bunch of HTML decoration.
@@ -81,7 +81,7 @@ module Results
     end
 
     def group_key(group)
-      group.group_name.vanilla
+      group.code.vanilla
     end
   end
 end

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -76,7 +76,7 @@ module Results
     end
 
     def group_key(group)
-      group.group_name.gsub(/[^a-z0-9]/i, "")
+      group.group_name.vanilla
     end
   end
 end

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -74,8 +74,8 @@ module Results
       when "location" then answer.attributes.slice(*%w[latitude longitude altitude accuracy]).to_s
       else
         value = answer.value.presence
-        # TODO: Is this parsing something we want to do? Is there already a conventional way?
-        #   Output is SUPER GROSS without it because of copy/paste from MS Word.
+        # Data that's been copied from MS Word contains a bunch of HTML decoration.
+        # Get rid of that via simple_format.
         value&.match(/\A<!--/) ? simple_format(value) : value&.to_s
       end
     end

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -21,6 +21,11 @@ module Results
       object["ResponseReviewed"] = response.reviewed?
       root = response.root_node_including_tree(:choices, form_item: :question, option_node: :option_set)
       add_answers(root, object)
+      # Make sure we include everything from the metadata in our response,
+      # even if the Response didn't include that answer.
+      response.form.c.map do |c|
+        object[c.code.vanilla] ||= nil
+      end
       object
     end
 

--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -3,6 +3,8 @@
 module Results
   # Generates cached JSON for a given response.
   class ResponseJsonGenerator
+    include ActionView::Helpers::TextHelper
+
     attr_accessor :response
 
     def initialize(response)
@@ -50,9 +52,9 @@ module Results
       set = {}
       answer_set.children.each do |answer|
         option_node = answer.option_node
-        set[option_node.level_name] = answer.option_name
+        set[option_node.level_name] = answer.option_name if option_node
       end
-      set
+      set.to_s
     end
 
     def value_for(answer)
@@ -63,9 +65,13 @@ module Results
       when "integer", "counter" then answer.value&.to_i
       when "decimal" then answer.value&.to_f
       when "select_one" then answer.option_name
-      when "select_multiple" then answer.choices.empty? ? nil : answer.choices.map(&:option_name).sort
-      when "location" then answer.attributes.slice(*%w[latitude longitude altitude accuracy])
-      else answer.value.presence
+      when "select_multiple" then answer.choices.empty? ? nil : answer.choices.map(&:option_name).sort.to_s
+      when "location" then answer.attributes.slice(*%w[latitude longitude altitude accuracy]).to_s
+      else
+        value = answer.value.presence
+        # TODO: Is this parsing something we want to do? Is there already a conventional way?
+        #   Output is SUPER GROSS without it because of copy/paste from MS Word.
+        value&.match(/\A<!--/) ? simple_format(value) : value.to_s
       end
     end
 

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -27,10 +27,7 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   end
 
   def transform_json_for_root(json)
-    # Trim off URL params; something internally
-    # is trying to keep `mode` when generating `metadata_url`.
-    json["@odata.context"].sub!("?mode=m", "")
-    json
+    trim_context_params(json)
   end
 
   def transform_schema_for_metadata(_schema)
@@ -43,6 +40,13 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
       response = Response.find(response_id)
       Results::ResponseJsonGenerator.new(response).as_json
     end
+    trim_context_params(json)
+  end
+
+  # Trim off URL params; something internally
+  # is trying to keep `mode` when generating `metadata_url`.
+  def trim_context_params(json)
+    json["@odata.context"].sub!("?mode=m", "")
     json
   end
 

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -38,8 +38,11 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   end
 
   def transform_json_for_resource_feed(json)
-    # TODO: Use Tom's code here
-    json[:value] = []
+    json[:value] = json[:value].map do |response|
+      response_id = response["Id"]
+      response = Response.find(response_id)
+      Results::ResponseJsonGenerator.new(response).as_json
+    end
     json
   end
 

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -51,7 +51,7 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   # Trim off URL params; something internally
   # is trying to keep `mode` when generating `metadata_url`.
   def trim_context_params(json)
-    json["@odata.context"].sub!("?mode=m", "")
+    json["@odata.context"]&.sub!("?mode=m", "")
     json
   end
 

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -38,7 +38,8 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
     json[:value] = json[:value].map do |response|
       response_id = response["Id"]
       response = Response.find(response_id)
-      Results::ResponseJsonGenerator.new(response).as_json
+      # TODO: Either lazy cache this here, or ensure a bg job will do it?
+      response.cached_json || Results::ResponseJsonGenerator.new(response).as_json
     end
     trim_context_params(json)
   end

--- a/config/initializers/string.rb
+++ b/config/initializers/string.rb
@@ -11,6 +11,11 @@ class String
     mb_chars.normalize(:kd).gsub(/[^\x00-\x7F]/n, "")
   end
 
+  # Temporary method to rid a string of pesky characters that might annoy Power BI.
+  def vanilla
+    normalize.gsub(/[^a-z0-9._\- ]/i, "").to_s
+  end
+
   def ucwords
     split(" ").map(&:capitalize).join(" ")
   end

--- a/db/migrate/20200508052833_add_cached_json_to_response.rb
+++ b/db/migrate/20200508052833_add_cached_json_to_response.rb
@@ -1,0 +1,28 @@
+class AddCachedJsonToResponse < ActiveRecord::Migration[5.2]
+  def change
+    add_column :responses, :cached_json, :jsonb
+
+    reversible do |dir|
+      dir.up do
+        cache_responses
+      end
+    end
+  end
+
+  def cache_responses
+    # TODO: Temporary filter
+    # haitimalaria riverblindnessnigeria2017
+    mission_ids = ["sandbox"].map do |compact_name|
+      Mission.find_by(compact_name: compact_name).id
+    end
+    limited_responses = Response.where(mission_id: mission_ids)
+
+    total = limited_responses.count
+    curr = 0
+    limited_responses.find_each do |response|
+      json = Results::ResponseJsonGenerator.new(response).as_json
+      puts "Updating #{response.shortcode}... (#{curr += 1} / #{total})"
+      response.update!(cached_json: json)
+    end
+  end
+end

--- a/db/migrate/20200508052833_add_cached_json_to_response.rb
+++ b/db/migrate/20200508052833_add_cached_json_to_response.rb
@@ -1,28 +1,7 @@
+# frozen_string_literal: true
+
 class AddCachedJsonToResponse < ActiveRecord::Migration[5.2]
   def change
     add_column :responses, :cached_json, :jsonb
-
-    reversible do |dir|
-      dir.up do
-        cache_responses
-      end
-    end
-  end
-
-  def cache_responses
-    # TODO: Temporary filter
-    # haitimalaria riverblindnessnigeria2017
-    mission_ids = ["sandbox"].map do |compact_name|
-      Mission.find_by(compact_name: compact_name).id
-    end
-    limited_responses = Response.where(mission_id: mission_ids)
-
-    total = limited_responses.count
-    curr = 0
-    limited_responses.find_each do |response|
-      json = Results::ResponseJsonGenerator.new(response).as_json
-      puts "Updating #{response.shortcode}... (#{curr += 1} / #{total})"
-      response.update!(cached_json: json)
-    end
   end
 end

--- a/db/migrate/20200508155813_populate_response_cached_json.rb
+++ b/db/migrate/20200508155813_populate_response_cached_json.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class PopulateResponseCachedJson < ActiveRecord::Migration[5.2]
+  # Disable transaction wrapper so that the update queries will be committed even if we
+  # have to fail the transaction part-way through.
+  disable_ddl_transaction!
+
+  def up
+    # TODO: Temporary filter; sandbox haitimalaria riverblindnessnigeria2017
+    mission_ids = %w[sandbox haitimalaria riverblindnessnigeria2017].map do |compact_name|
+      Mission.find_by(compact_name: compact_name).id
+    end
+    responses = Response.where(mission_id: mission_ids)
+    remaining_responses = ENV["FORCE_REDO"] ? responses : responses.where(cached_json: nil)
+
+    cache_responses(remaining_responses)
+  end
+
+  def cache_responses(responses)
+    # Disable logging for this db-heavy migration.
+    old_level = ActiveRecord::Base.logger.level
+    ActiveRecord::Base.logger.level = 1
+
+    total = responses.count
+    curr = 0
+    responses.find_each do |response|
+      json = Results::ResponseJsonGenerator.new(response).as_json
+      puts "Updating #{response.shortcode}... (#{curr += 1} / #{total})"
+      response.update!(cached_json: json)
+    end
+
+    ActiveRecord::Base.logger.level = old_level
+  end
+end

--- a/db/migrate/20200508155813_populate_response_cached_json.rb
+++ b/db/migrate/20200508155813_populate_response_cached_json.rb
@@ -10,7 +10,11 @@ class PopulateResponseCachedJson < ActiveRecord::Migration[5.2]
     mission_ids = %w[sandbox haitimalaria riverblindnessnigeria2017].map do |compact_name|
       Mission.find_by(compact_name: compact_name).id
     end
-    responses = Response.where(mission_id: mission_ids)
+    # form_ids = Form.live.distinct(:id).pluck(:id)
+    form_ids = Form.live.distinct(:id).map do |form|
+      form.id if form.name.match?(/CDDAtt/i)
+    end.compact
+    responses = Response.where(mission_id: mission_ids, form_id: form_ids)
     remaining_responses = ENV["FORCE_REDO"] ? responses : responses.where(cached_json: nil)
 
     cache_responses(remaining_responses)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_052833) do
+ActiveRecord::Schema.define(version: 2020_05_08_155813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_10_153801) do
+ActiveRecord::Schema.define(version: 2020_05_08_052833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -411,6 +411,7 @@ ActiveRecord::Schema.define(version: 2020_04_10_153801) do
   end
 
   create_table "responses", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.jsonb "cached_json"
     t.datetime "checked_out_at"
     t.uuid "checked_out_by_id"
     t.datetime "created_at", null: false

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -107,21 +107,12 @@ def build_item(item, form, parent, evaluator)
   if item.is_a?(Hash) && item.key?(:repeating)
     item = item[:repeating]
     item = {items: item} if item.is_a?(Array)
-    group = create(:qing_group,
-      parent: parent,
-      form: form,
-      # Group name is required, but may not be defined on `item`.
-      group_name_en: item[:name] || "Group #{rand(100_000)}",
-      group_hint_en: item[:name],
-      group_item_name: item[:item_name],
-      repeatable: true)
+    attribs = {parent: parent, form: form, group_item_name: item[:item_name], repeatable: true}
+    attribs[:group_name_en] = attribs[:group_hint_en] = item[:name] if item[:name].present?
+    group = create(:qing_group, attribs)
     item[:items].each { |c| build_item(c, form, group, evaluator) }
   elsif item.is_a?(Array)
-    group = create(:qing_group,
-      parent: parent,
-      form: form,
-      group_name_en: "Group Name",
-      group_hint_en: "Group Hint")
+    group = create(:qing_group, parent: parent, form: form)
     item.each { |q| build_item(q, form, group, evaluator) }
   else # must be a questioning
     create_questioning(item, form, parent: parent, evaluator: evaluator)

--- a/spec/factories/qing_groups.rb
+++ b/spec/factories/qing_groups.rb
@@ -53,8 +53,8 @@ FactoryGirl.define do
     parent { form.root_group }
     type "QingGroup"
     mission { form.mission }
-    group_name "group"
-    group_hint "hint"
+    sequence(:group_name) { |i| "Group #{i}" }
+    sequence(:group_hint) { |i| "Group Hint #{i}" }
     one_screen true
   end
 end

--- a/spec/factories/responses.rb
+++ b/spec/factories/responses.rb
@@ -6,6 +6,7 @@
 # Table name: responses
 #
 #  id                   :uuid             not null, primary key
+#  cached_json          :jsonb
 #  checked_out_at       :datetime
 #  incomplete           :boolean          default(FALSE), not null
 #  odk_hash             :string(255)

--- a/spec/fixtures/odata/basic_metadata.xml
+++ b/spec/fixtures/odata/basic_metadata.xml
@@ -14,12 +14,12 @@
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
-        <Property Name="*q_name1*" Type="Edm.Int64" Nullable="true"/>
-        <Property Name="*q_name2*" Type="Edm.String" Nullable="true"/>
-        <Property Name="*q_name3*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code1*" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="*q_code2*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code3*" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form2*" BaseType="NEMO.Response">
-        <Property Name="*q_name4*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code4*" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityContainer Name="NEMOService">
         <EntitySet Name="Response" EntityType="NEMO.Response">

--- a/spec/fixtures/odata/nested_groups_metadata.xml
+++ b/spec/fixtures/odata/nested_groups_metadata.xml
@@ -3,16 +3,16 @@
   <edmx:DataServices>
     <Schema Namespace="NEMO" xmlns="http://docs.oasis-open.org/odata/ns/edm">
       <EntityType Name="Group.*form1*.G1">
-        <Property Name="*q_name2*" Type="Edm.String" Nullable="true"/>
-        <Property Name="*q_name3*" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="*q_code2*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code3*" Type="Edm.Int64" Nullable="true"/>
       </EntityType>
       <EntityType Name="Group.*form1*.G2">
-        <Property Name="*q_name4*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code4*" Type="Edm.String" Nullable="true"/>
         <Property Name="*group_name1*" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
       </EntityType>
       <EntityType Name="Group.*form1*.G2.G1">
-        <Property Name="*q_name5*" Type="Edm.Int64" Nullable="true"/>
-        <Property Name="*q_name6*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code5*" Type="Edm.Int64" Nullable="true"/>
+        <Property Name="*q_code6*" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Response">
         <Key>
@@ -26,7 +26,7 @@
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
-        <Property Name="*q_name1*" Type="Edm.String" Nullable="true"/>
+        <Property Name="*q_code1*" Type="Edm.String" Nullable="true"/>
         <Property Name="*group_name2*" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
         <Property Name="*group_name3*" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
       </EntityType>

--- a/spec/fixtures/odata/nested_groups_metadata.xml
+++ b/spec/fixtures/odata/nested_groups_metadata.xml
@@ -8,7 +8,7 @@
       </EntityType>
       <EntityType Name="Group.*form1*.G2">
         <Property Name="*q_code4*" Type="Edm.String" Nullable="true"/>
-        <Property Name="*group_name1*" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
+        <Property Name="Group 3" Type="NEMO.Group.*form1*.G2.G1" Nullable="true"/>
       </EntityType>
       <EntityType Name="Group.*form1*.G2.G1">
         <Property Name="*q_code5*" Type="Edm.Int64" Nullable="true"/>
@@ -27,8 +27,8 @@
       </EntityType>
       <EntityType Name="Responses: *form1*" BaseType="NEMO.Response">
         <Property Name="*q_code1*" Type="Edm.String" Nullable="true"/>
-        <Property Name="*group_name2*" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
-        <Property Name="*group_name3*" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
+        <Property Name="Group 1" Type="NEMO.Group.*form1*.G1" Nullable="true"/>
+        <Property Name="Group 2" Type="NEMO.Group.*form1*.G2" Nullable="true"/>
       </EntityType>
       <EntityContainer Name="NEMOService">
         <EntitySet Name="Group.*form1*.G1" EntityType="NEMO.Group.*form1*.G1">

--- a/spec/fixtures/odk/forms/default_patterns.xml
+++ b/spec/fixtures/odk/forms/default_patterns.xml
@@ -42,10 +42,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode1*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode1*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode2*:label">
             <value>Integer Question Title 1</value>

--- a/spec/fixtures/odk/forms/grid_group_with_condition.xml
+++ b/spec/fixtures/odk/forms/grid_group_with_condition.xml
@@ -17,10 +17,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode2*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode2*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode1*:label">
             <value>Text Question Title 1</value>

--- a/spec/fixtures/odk/forms/multi_screen_gridable.xml
+++ b/spec/fixtures/odk/forms/multi_screen_gridable.xml
@@ -15,10 +15,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode1*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode1*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode2*:label">
             <value>Select One Question Title 1</value>

--- a/spec/fixtures/odk/forms/multi_screen_group.xml
+++ b/spec/fixtures/odk/forms/multi_screen_group.xml
@@ -16,10 +16,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode1*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode1*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode2*:label">
             <value>Text Question Title 1</value>

--- a/spec/fixtures/odk/forms/multiscreen_group_with_multilevel.xml
+++ b/spec/fixtures/odk/forms/multiscreen_group_with_multilevel.xml
@@ -38,10 +38,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode1*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode1*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode2*:label">
             <value>Text Question Title 1</value>

--- a/spec/fixtures/odk/forms/nested_repeat_group.xml
+++ b/spec/fixtures/odk/forms/nested_repeat_group.xml
@@ -49,10 +49,10 @@
             <value>Repeat Group 2</value>
           </text>
           <text id="*itemcode10*:label">
-            <value>Group Name</value>
+            <value>Group 4</value>
           </text>
           <text id="*itemcode10*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 4</value>
           </text>
           <text id="*itemcode2*:label">
             <value>Text Question Title 1</value>

--- a/spec/fixtures/odk/forms/non_repeat_group_with_condition.xml
+++ b/spec/fixtures/odk/forms/non_repeat_group_with_condition.xml
@@ -17,10 +17,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode2*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode2*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode1*:label">
             <value>Text Question Title 1</value>

--- a/spec/fixtures/odk/forms/non_repeat_group_with_multilevel_select.xml
+++ b/spec/fixtures/odk/forms/non_repeat_group_with_multilevel_select.xml
@@ -38,10 +38,10 @@
       <itext>
         <translation lang="English">
           <text id="*itemcode1*:label">
-            <value>Group Name</value>
+            <value>Group 1</value>
           </text>
           <text id="*itemcode1*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 1</value>
           </text>
           <text id="*itemcode2*:label">
             <value>Text Question Title 1</value>

--- a/spec/fixtures/odk/forms/repeat_group.xml
+++ b/spec/fixtures/odk/forms/repeat_group.xml
@@ -35,10 +35,10 @@
             <value>Hi’ "<output value="/data/*itemcode1*/*itemcode2*"/>"</value>
           </text>
           <text id="*itemcode5*:label">
-            <value>Group Name</value>
+            <value>Group 2</value>
           </text>
           <text id="*itemcode5*:hint">
-            <value>Group Hint</value>
+            <value>Group Hint 2</value>
           </text>
           <text id="*itemcode8*:label">
             <value>Grp2</value>

--- a/spec/fixtures/response_json/basic.json
+++ b/spec/fixtures/response_json/basic.json
@@ -1,0 +1,32 @@
+{
+  "ResponseID": "*id1*",
+  "ResponseShortcode": "*shortcode1*",
+  "FormName": "Sample Form 1",
+  "ResponseSubmitterName": "A User 1",
+  "ResponseSubmitDate": "2020-04-20T06:30:00-06:00",
+  "ResponseReviewed": false,
+  "TextQ1": "foo✓",
+  "SelectOneQ2": {
+    "Country": "Canada",
+    "City": "Calgary"
+  },
+  "LongTextQ3": "alpha",
+  "IntegerQ4": 100,
+  "DecimalQ5": -123.5,
+  "LocationQ6": {
+    "latitude": "15.937378",
+    "longitude": "44.36453",
+    "altitude": null,
+    "accuracy": null
+  },
+  "SelectOneQ7": "Cat",
+  "SelectOneQ8": "Dog",
+  "SelectOneQ9": "Cat",
+  "SelectMultipleQ10": [
+    "Cat",
+    "Dog"
+  ],
+  "DatetimeQ11": "2015-10-12T12:15:12-06:00",
+  "DateQ12": "2014-11-09",
+  "TimeQ13": "23:15:00"
+}

--- a/spec/fixtures/response_json/basic.json
+++ b/spec/fixtures/response_json/basic.json
@@ -20,8 +20,10 @@
     "accuracy": null
   },
   "SelectOneQ7": "Cat",
-  "SelectOneQ8": "Dog",
-  "SelectOneQ9": "Cat",
+  "Group1": {
+    "SelectOneQ8": "Dog",
+    "SelectOneQ9": "Cat"
+  },
   "SelectMultipleQ10": [
     "Cat",
     "Dog"

--- a/spec/fixtures/response_json/basic.json
+++ b/spec/fixtures/response_json/basic.json
@@ -6,29 +6,19 @@
   "ResponseSubmitDate": "2020-04-20T06:30:00-06:00",
   "ResponseReviewed": false,
   "TextQ1": "foo✓",
-  "SelectOneQ2": {
-    "Country": "Canada",
-    "City": "Calgary"
-  },
+  "SelectOneQ2": "{\"Country\"=>\"Canada\", \"City\"=>\"Calgary\"}",
   "LongTextQ3": "alpha",
   "IntegerQ4": 100,
   "DecimalQ5": -123.5,
-  "LocationQ6": {
-    "latitude": "15.937378",
-    "longitude": "44.36453",
-    "altitude": null,
-    "accuracy": null
-  },
+  "LocationQ6": "{\"latitude\"=>0.15937378e2, \"longitude\"=>0.4436453e2, \"altitude\"=>nil, \"accuracy\"=>nil}",
   "SelectOneQ7": "Cat",
-  "Group1": {
+  "Group 1": {
     "SelectOneQ8": "Dog",
     "SelectOneQ9": "Cat"
   },
-  "SelectMultipleQ10": [
-    "Cat",
-    "Dog"
-  ],
+  "SelectMultipleQ10": "[\"Cat\", \"Dog\"]",
   "DatetimeQ11": "2015-10-12T12:15:12-06:00",
   "DateQ12": "2014-11-09",
-  "TimeQ13": "23:15:00"
+  "TimeQ13": "23:15:00",
+  "ImageQ14": null
 }

--- a/spec/fixtures/response_json/repeats.json
+++ b/spec/fixtures/response_json/repeats.json
@@ -1,0 +1,53 @@
+{
+  "ResponseID": "*id1*",
+  "ResponseShortcode": "*shortcode1*",
+  "FormName": "Sample Form 1",
+  "ResponseSubmitterName": "A User 1",
+  "ResponseSubmitDate": "2020-04-20T06:30:00-06:00",
+  "ResponseReviewed": true,
+  "IntegerQ1": 1,
+  "Fruit": [
+    {
+      "TextQ2": "Apple",
+      "IntegerQ3": 1,
+      "SelectMultipleQ4": [
+        "Cat",
+        "Dog"
+      ],
+      "Slice": [
+        {
+          "DecimalQ5": 1.65
+        },
+        {
+          "DecimalQ5": 1.3
+        }
+      ]
+    },
+    {
+      "TextQ2": "Banana",
+      "IntegerQ3": 2,
+      "SelectMultipleQ4": [
+        "Cat"
+      ],
+      "Slice": [
+        {
+          "DecimalQ5": 1.27
+        },
+        {
+          "DecimalQ5": 1.77
+        }
+      ]
+    }
+  ],
+  "IntegerQ6": 2,
+  "Vegetable": [
+    {
+      "TextQ7": "Asparagus",
+      "SelectOneQ8": {
+        "Country": "Ghana",
+        "City": "Accra"
+      },
+      "IntegerQ9": 3
+    }
+  ]
+}

--- a/spec/fixtures/response_json/repeats.json
+++ b/spec/fixtures/response_json/repeats.json
@@ -10,10 +10,7 @@
     {
       "TextQ2": "Apple",
       "IntegerQ3": 1,
-      "SelectMultipleQ4": [
-        "Cat",
-        "Dog"
-      ],
+      "SelectMultipleQ4": "[\"Cat\", \"Dog\"]",
       "Slice": [
         {
           "DecimalQ5": 1.65
@@ -26,9 +23,7 @@
     {
       "TextQ2": "Banana",
       "IntegerQ3": 2,
-      "SelectMultipleQ4": [
-        "Cat"
-      ],
+      "SelectMultipleQ4": "[\"Cat\"]",
       "Slice": [
         {
           "DecimalQ5": 1.27
@@ -43,10 +38,7 @@
   "Vegetable": [
     {
       "TextQ7": "Asparagus",
-      "SelectOneQ8": {
-        "Country": "Ghana",
-        "City": "Accra"
-      },
+      "SelectOneQ8": "{\"Country\"=>\"Ghana\", \"City\"=>\"Accra\"}",
       "IntegerQ9": 3
     }
   ]

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -6,6 +6,7 @@
 # Table name: responses
 #
 #  id                   :uuid             not null, primary key
+#  cached_json          :jsonb
 #  checked_out_at       :datetime
 #  incomplete           :boolean          default(FALSE), not null
 #  odk_hash             :string(255)

--- a/spec/models/results/response_json_generator_spec.rb
+++ b/spec/models/results/response_json_generator_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Results::ResponseJsonGenerator, :reset_factory_sequences do
+  let(:submission_time) { Time.zone.parse("2020-04-20 12:30 UTC") }
+  subject(:object) { described_class.new(response).as_json }
+
+  around do |example|
+    # Use a weird timezone so we know times are handled properly.
+    in_timezone("Saskatchewan") do
+      # Need to freeze the time so the times in the expectation file match.
+      # The times shown in the resulting JSON should be in the current zone, not UTC.
+      # So e.g. 6:30am instead of 12:30pm.
+      Timecop.freeze(submission_time) { example.run }
+    end
+  end
+
+  context "response with various question types" do
+    let(:form) do
+      create(:form, question_types: ["text",                       # 1
+                                     "geo_multilevel_select_one",  # 2
+                                     "long_text",                  # 3
+                                     "integer",                    # 4
+                                     "decimal",                    # 5
+                                     "location",                   # 6
+                                     "select_one",                 # 7
+                                     %w[select_one select_one],    # 8, 9
+                                     "select_multiple",            # 10
+                                     "datetime",                   # 11
+                                     "date",                       # 12
+                                     "time",                       # 13
+                                     "image"])                     # 14
+    end
+
+    context "full multilevel answer" do
+      let(:response) do
+        create(:response,
+          form: form,
+          answer_values: ["foo✓", %w[Canada Calgary],
+                          "alpha", 100, -123.50,
+                          "15.937378 44.36453", "Cat", %w[Dog Cat], %w[Dog Cat],
+                          "2015-10-12 18:15:12 UTC", "2014-11-09", "23:15"])
+      end
+
+      it "produces correct json" do
+        is_expected.to match_json(prepare_response_json_expectation("basic.json"))
+      end
+    end
+  end
+
+  def prepare_response_json_expectation(filename)
+    prepare_fixture("response_json/#{filename}",
+      id: [response.id], shortcode: [response.shortcode])
+  end
+end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "$metadata" do
+describe "OData $metadata" do
   include_context "odata"
 
   let(:path) { "#{mission_api_route}/$metadata" }
@@ -19,8 +19,7 @@ describe "$metadata" do
   context "with nested groups" do
     include_context "odata with nested groups"
     it do
-      # TODO: These names will be generated differently in an upcoming commit.
-      substitutions = {group_name: ["Group Name (1)", "Group Name (1)", "Group Name (2)"]}
+      substitutions = {group_name: ["Group 3 (1)", "Group 1 (1)", "Group 2 (2)"]}
       expect_output_fixture("nested_groups_metadata.xml", forms: [form], substitutions: substitutions)
     end
   end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -16,11 +16,8 @@ describe "OData $metadata" do
     it { expect_fixture("basic_metadata.xml", forms: [form, form_with_no_responses]) }
   end
 
-  context "with nested groups" do
+  context "with nested groups", :reset_factory_sequences do
     include_context "odata with nested groups"
-    it do
-      substitutions = {group_name: ["Group 3 (1)", "Group 1 (1)", "Group 2 (2)"]}
-      expect_fixture("nested_groups_metadata.xml", forms: [form], substitutions: substitutions)
-    end
+    it { expect_fixture("nested_groups_metadata.xml", forms: [form]) }
   end
 end

--- a/spec/requests/odata/metadata_spec.rb
+++ b/spec/requests/odata/metadata_spec.rb
@@ -8,19 +8,19 @@ describe "OData $metadata" do
   let(:path) { "#{mission_api_route}/$metadata" }
 
   context "with no forms" do
-    it { expect_output_fixture("empty_metadata.xml") }
+    it { expect_fixture("empty_metadata.xml") }
   end
 
   context "with several basic forms" do
     include_context "odata with basic forms"
-    it { expect_output_fixture("basic_metadata.xml", forms: [form, form_with_no_responses]) }
+    it { expect_fixture("basic_metadata.xml", forms: [form, form_with_no_responses]) }
   end
 
   context "with nested groups" do
     include_context "odata with nested groups"
     it do
       substitutions = {group_name: ["Group 3 (1)", "Group 1 (1)", "Group 2 (2)"]}
-      expect_output_fixture("nested_groups_metadata.xml", forms: [form], substitutions: substitutions)
+      expect_fixture("nested_groups_metadata.xml", forms: [form], substitutions: substitutions)
     end
   end
 end

--- a/spec/requests/odata/resource_spec.rb
+++ b/spec/requests/odata/resource_spec.rb
@@ -14,23 +14,23 @@ describe "OData resource" do
     let(:path) { "#{mission_api_route}/Responses-invalid" }
 
     it "renders as expected" do
-      expect_output({
+      expect_json(
         "error": {
           "code": "",
           "message": "Resource not found for the segment 'Responses-invalid'."
         }
-      }.to_json)
+      )
     end
   end
 
-  context "with basic form" do
+  context "with basic form", :reset_factory_sequences do
     include_context "odata with basic forms"
 
     let(:path) { "#{mission_api_route}/Responses-#{form.id}" }
     let(:first_response) { form.responses.first }
 
     it "renders as expected" do
-      expect_output({
+      expect_json(
         "@odata.context": "http://www.example.com/en/m/#{get_mission.compact_name}" \
           "/odata/v1/$metadata#Responses: #{form.name}",
         value: [
@@ -44,7 +44,7 @@ describe "OData resource" do
                                             "SelectOneQ2": "Dog",
                                             "TextQ3": "Foo")
         ]
-      }.to_json)
+      )
     end
   end
 end

--- a/spec/requests/odata/resource_spec.rb
+++ b/spec/requests/odata/resource_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "OData resource" do
+  include_context "odata"
+
+  around do |example|
+    # Use a consistent timezone so the output matches.
+    in_timezone("Saskatchewan") { example.run }
+  end
+
+  context "with no forms" do
+    let(:path) { "#{mission_api_route}/Responses-invalid" }
+
+    it "renders as expected" do
+      expect_output({
+        "error": {
+          "code": "",
+          "message": "Resource not found for the segment 'Responses-invalid'."
+        }
+      }.to_json)
+    end
+  end
+
+  context "with basic form" do
+    include_context "odata with basic forms"
+
+    let(:path) { "#{mission_api_route}/Responses-#{form.id}" }
+    let(:first_response) { form.responses.first }
+
+    it "renders as expected" do
+      expect_output({
+        "@odata.context": "http://www.example.com/en/m/#{get_mission.compact_name}" \
+          "/odata/v1/$metadata#Responses: #{form.name}",
+        value: [
+          json_for(form, form.responses[0], "IntegerQ1": 3,
+                                            "SelectOneQ2": "Dog",
+                                            "TextQ3": "Baz"),
+          json_for(form, form.responses[1], "IntegerQ1": 2,
+                                            "SelectOneQ2": "Cat",
+                                            "TextQ3": "Bar"),
+          json_for(form, form.responses[2], "IntegerQ1": 1,
+                                            "SelectOneQ2": "Dog",
+                                            "TextQ3": "Foo")
+        ]
+      }.to_json)
+    end
+  end
+end
+
+def json_for(form, response, **answers)
+  {
+    "ResponseID": response.id,
+    "ResponseShortcode": response.shortcode,
+    "FormName": form.name,
+    "ResponseSubmitterName": response.user.name,
+    "ResponseSubmitDate": response.created_at.iso8601,
+    "ResponseReviewed": false
+  }.merge(answers)
+end

--- a/spec/requests/odata/root_spec.rb
+++ b/spec/requests/odata/root_spec.rb
@@ -9,10 +9,10 @@ describe "OData root" do
 
   context "with no forms" do
     it "renders as expected" do
-      expect_output({
+      expect_json(
         "@odata.context": "http://www.example.com/en/m/#{get_mission.compact_name}/odata/v1/$metadata",
         value: []
-      }.to_json)
+      )
     end
   end
 
@@ -22,13 +22,13 @@ describe "OData root" do
     it "renders as expected" do
       names = ["Responses: #{form.name}", "Responses: #{form_with_no_responses.name}"]
       urls = %W[Responses-#{form.id} Responses-#{form_with_no_responses.id}]
-      expect_output({
+      expect_json(
         "@odata.context": "http://www.example.com/en/m/#{get_mission.compact_name}/odata/v1/$metadata",
         value: [
           {name: names[0], kind: "EntitySet", url: urls[0]},
           {name: names[1], kind: "EntitySet", url: urls[1]}
         ]
-      }.to_json)
+      )
     end
   end
 end

--- a/spec/requests/odata/root_spec.rb
+++ b/spec/requests/odata/root_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe "root json" do
+describe "OData root" do
   include_context "odata"
 
   let(:path) { mission_api_route }

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -14,14 +14,13 @@ shared_context "odata" do
     Timecop.return
   end
 
-  def expect_output(expected)
+  def expect_json(expected)
     get(path)
     expect(response).to have_http_status(:ok)
-    # Don't worry about trailing newlines.
-    expect(response.body.rstrip).to eq(expected.rstrip)
+    expect(JSON.parse(response.body)).to match_json(JSON.pretty_generate(expected))
   end
 
-  def expect_output_fixture(filename, forms: [], substitutions: {})
+  def expect_fixture(filename, forms: [], substitutions: {})
     form_names = forms.map(&:name)
     form_q_codes = forms.map(&:questionings).flatten.map(&:code)
     get(path)

--- a/spec/support/contexts/odata.rb
+++ b/spec/support/contexts/odata.rb
@@ -23,11 +23,11 @@ shared_context "odata" do
 
   def expect_output_fixture(filename, forms: [], substitutions: {})
     form_names = forms.map(&:name)
-    form_q_names = forms.map(&:questionings).flatten.map(&:name)
+    form_q_codes = forms.map(&:questionings).flatten.map(&:code)
     get(path)
     expect(response).to have_http_status(:ok)
     expect(response.body).to eq(prepare_fixture("odata/#{filename}", form: form_names,
-                                                                     q_name: form_q_names,
+                                                                     q_code: form_q_codes,
                                                                      **substitutions))
   end
 end


### PR DESCRIPTION
This includes all the remaining code from the demo plus more specs and cleanup.

### Changes

- The `response_json_generator` can turn a Response into an OData JSON blob that matches the metadata (thanks Tom!)
- The `PopulateResponseCachedJson` migration can cache all existing responses via the new `cached_json` column
  - Any response that has already been cached will be skipped; env `FORCE_REDO` can disable this feature
  - All responses will be migrated by default; env `SUBSET` can be used to toggle filter logic to only migrate responses from a specific mission (for testing/debugging/demos)
- Resource routes (e.g. `/en/m/foo/odata/v1/Responses-formuuid123`) now spit out the `cached_json` for each response
- Pseudo group codes and other strings are generated using a temporary `vanilla` method that removes characters that may break Power BI
  - We still want form names to look like `Responses: My mission - with symbols and spaces` when displayed in Power BI, but SOME symbols break Power BI

### For a future PR

- Groups with the same name may collide, which may break Power BI; this will be fixed once we enforce unique `group_code`s
- We need a better way to deal with `vanilla`, it's smelly
- This PR is tested and verified in Power BI with basic repeat groups. More testing needs to be done before public release
  - For example with complex types like cascading geographic, and what happens when you add/remove qings from a form
  - I have these things written down to validate as part of 10704