### PR TITLE
10601 odata ui

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,6 +18,7 @@ rules:
   import/no-unresolved: ['error', { ignore: ['^javascripts/'] }]
   react/prefer-stateless-function: off
   jsx-a11y/label-has-for: ['error', { required: { some: ['nesting', 'id']}}]
+  no-new: off
 
 overrides:
   -

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,7 @@ globals:
   ELMO: true
   ReactRailsUJS: true
   Backbone: true
+  Clipboard: true
   Dropzone: true
   google: true
 rules:

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "whenever", "~> 0.9.4", require: false
 
 # JS/CSS
 gem "bootstrap", "~> 4.3.1"
+gem "clipboard-rails", "~> 1.7.1"
 gem "dropzonejs-rails", "~> 0.7.3"
 gem "font-awesome-rails", "~> 4.7"
 gem "jquery-fileupload-rails", "~> 0.4.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
     chronic (0.10.2)
     chunky_png (1.3.11)
     climate_control (0.2.0)
+    clipboard-rails (1.7.1)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -595,6 +596,7 @@ DEPENDENCIES
   cancancan (~> 2.3.0)
   capybara (~> 3.30)
   capybara-screenshot (~> 1.0)
+  clipboard-rails (~> 1.7.1)
   closure_tree!
   config (~> 1.7)
   configatron (~> 4.5.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,6 +25,7 @@
 //= require backbone
 //= require backbone_rails_sync
 //= require backbone_datalink
+//= require clipboard
 //= require i18n
 //= require i18n/translations
 //= require popper

--- a/app/assets/javascripts/views/response_list_view.js
+++ b/app/assets/javascripts/views/response_list_view.js
@@ -2,11 +2,13 @@
 ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.ApplicationView {
   get events() {
     return {
-      'click #export-link': 'showExportModal',
+      'click #export-csv-link': 'showExportCsvModal',
+      'click #export-odata-link': 'showExportODataModal',
     };
   }
 
   initialize(options) {
+    this.$('#export-dropdown').dropdown();
     this.reloadCount = 0;
     if (options.refreshInterval > 0) {
       setInterval(this.fetch.bind(this), options.refreshInterval);
@@ -16,9 +18,14 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
     }
   }
 
-  showExportModal(event) {
+  showExportCsvModal(event) {
     event.preventDefault();
-    this.$('#export-modal').modal('show');
+    this.$('#export-csv-modal').modal('show');
+  }
+
+  showExportODataModal(event) {
+    event.preventDefault();
+    this.$('#export-odata-modal').modal('show');
   }
 
   fetch() {

--- a/app/assets/javascripts/views/response_list_view.js
+++ b/app/assets/javascripts/views/response_list_view.js
@@ -4,12 +4,14 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
     return {
       'click #export-csv-link': 'showExportCsvModal',
       'click #export-odata-link': 'showExportODataModal',
-      'click #api_url .control a': 'selectApiUrl',
+      'click #copy-value': 'selectApiUrl',
     };
   }
 
   initialize(options) {
     this.$('#export-dropdown').dropdown();
+    // eslint-disable-next-line no-new
+    new Clipboard('#copy-btn');
     this.reloadCount = 0;
     if (options.refreshInterval > 0) {
       setInterval(this.fetch.bind(this), options.refreshInterval);
@@ -30,8 +32,7 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
   }
 
   selectApiUrl() {
-    this.$('#api_url .control pre').selectText();
-    return false;
+    this.$('#copy-value').selectText();
   }
 
   fetch() {

--- a/app/assets/javascripts/views/response_list_view.js
+++ b/app/assets/javascripts/views/response_list_view.js
@@ -4,6 +4,7 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
     return {
       'click #export-csv-link': 'showExportCsvModal',
       'click #export-odata-link': 'showExportODataModal',
+      'click #api_url .control a': 'selectApiUrl',
     };
   }
 
@@ -26,6 +27,11 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
   showExportODataModal(event) {
     event.preventDefault();
     this.$('#export-odata-modal').modal('show');
+  }
+
+  selectApiUrl() {
+    this.$('#api_url .control pre').selectText();
+    return false;
   }
 
   fetch() {

--- a/app/assets/javascripts/views/response_list_view.js
+++ b/app/assets/javascripts/views/response_list_view.js
@@ -4,14 +4,13 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
     return {
       'click #export-csv-link': 'showExportCsvModal',
       'click #export-odata-link': 'showExportODataModal',
-      'click #copy-value': 'selectApiUrl',
+      'click #copy-value-api_url': 'selectApiUrl',
     };
   }
 
   initialize(options) {
     this.$('#export-dropdown').dropdown();
-    // eslint-disable-next-line no-new
-    new Clipboard('#copy-btn');
+    new Clipboard('#copy-btn-api_url');
     this.reloadCount = 0;
     if (options.refreshInterval > 0) {
       setInterval(this.fetch.bind(this), options.refreshInterval);
@@ -32,7 +31,7 @@ ELMO.Views.ResponseListView = class ResponseListView extends ELMO.Views.Applicat
   }
 
   selectApiUrl() {
-    this.$('#copy-value').selectText();
+    this.$('#copy-value-api_url').selectText();
   }
 
   fetch() {

--- a/app/assets/javascripts/views/settings_view.js
+++ b/app/assets/javascripts/views/settings_view.js
@@ -8,7 +8,7 @@ ELMO.Views.SettingsView = class SettingsView extends ELMO.Views.ApplicationView 
 
   get events() {
     return {
-      'click #external_sql .control a': 'select_external_sql',
+      'click #external_sql .control a': 'selectExternalSql',
       'click .adapter-settings a.show-credential-fields': 'show_change_credential_fields',
       'click .using-incoming-sms-token': 'show_using_incoming_sms_token_modal',
       'click .using-universal-sms-token': 'show_using_universal_sms_token_modal',
@@ -21,7 +21,7 @@ ELMO.Views.SettingsView = class SettingsView extends ELMO.Views.ApplicationView 
     return this.show_credential_fields_with_errors();
   }
 
-  select_external_sql(event) {
+  selectExternalSql() {
     this.$('#external_sql .control pre').selectText();
     return false;
   }

--- a/app/assets/javascripts/views/settings_view.js
+++ b/app/assets/javascripts/views/settings_view.js
@@ -8,7 +8,7 @@ ELMO.Views.SettingsView = class SettingsView extends ELMO.Views.ApplicationView 
 
   get events() {
     return {
-      'click #external_sql .control a': 'selectExternalSql',
+      'click #copy-btn': 'selectExternalSql',
       'click .adapter-settings a.show-credential-fields': 'show_change_credential_fields',
       'click .using-incoming-sms-token': 'show_using_incoming_sms_token_modal',
       'click .using-universal-sms-token': 'show_using_universal_sms_token_modal',
@@ -18,12 +18,13 @@ ELMO.Views.SettingsView = class SettingsView extends ELMO.Views.ApplicationView 
 
   initialize(options) {
     this.need_credentials = options.need_credentials || {};
+    // eslint-disable-next-line no-new
+    new Clipboard('#copy-btn');
     return this.show_credential_fields_with_errors();
   }
 
   selectExternalSql() {
-    this.$('#external_sql .control pre').selectText();
-    return false;
+    this.$('#copy-value').selectText();
   }
 
   show_change_credential_fields(event) {

--- a/app/assets/javascripts/views/settings_view.js
+++ b/app/assets/javascripts/views/settings_view.js
@@ -8,7 +8,7 @@ ELMO.Views.SettingsView = class SettingsView extends ELMO.Views.ApplicationView 
 
   get events() {
     return {
-      'click #copy-btn': 'selectExternalSql',
+      'click #copy-btn-external_sql': 'selectExternalSql',
       'click .adapter-settings a.show-credential-fields': 'show_change_credential_fields',
       'click .using-incoming-sms-token': 'show_using_incoming_sms_token_modal',
       'click .using-universal-sms-token': 'show_using_universal_sms_token_modal',
@@ -18,13 +18,12 @@ ELMO.Views.SettingsView = class SettingsView extends ELMO.Views.ApplicationView 
 
   initialize(options) {
     this.need_credentials = options.need_credentials || {};
-    // eslint-disable-next-line no-new
-    new Clipboard('#copy-btn');
+    new Clipboard('#copy-btn-external_sql');
     return this.show_credential_fields_with_errors();
   }
 
   selectExternalSql() {
-    this.$('#copy-value').selectText();
+    this.$('#copy-value-external_sql').selectText();
   }
 
   show_change_credential_fields(event) {

--- a/app/assets/stylesheets/global/_buttons.scss
+++ b/app/assets/stylesheets/global/_buttons.scss
@@ -9,3 +9,11 @@
     color: $text-over-accent-color;
   }
 }
+
+// Remove Bootstrap button styling to make it look like a regular <a>
+.btn-link.btn-a {
+  padding: 0;
+  border: 0;
+  vertical-align: baseline;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/global/_buttons.scss
+++ b/app/assets/stylesheets/global/_buttons.scss
@@ -12,8 +12,8 @@
 
 // Remove Bootstrap button styling to make it look like a regular <a>
 .btn-link.btn-a {
-  padding: 0;
   border: 0;
-  vertical-align: baseline;
   cursor: pointer;
+  padding: 0;
+  vertical-align: baseline;
 }

--- a/app/assets/stylesheets/global/html_forms/elmo_forms/_fields.scss
+++ b/app/assets/stylesheets/global/html_forms/elmo_forms/_fields.scss
@@ -105,7 +105,7 @@
 
     pre {
       background-color: $pre-bg;
-      border: 1px solid #ccc;
+      border: 1px solid $lighter-gray;
       font-size: 8pt;
       margin: 0 0 3px;
       overflow: auto;

--- a/app/assets/stylesheets/global/html_forms/elmo_forms/_fields.scss
+++ b/app/assets/stylesheets/global/html_forms/elmo_forms/_fields.scss
@@ -102,6 +102,16 @@
         }
       }
     }
+
+    pre {
+      background-color: $pre-bg;
+      border: 1px solid #ccc;
+      font-size: 8pt;
+      margin: 0 0 3px;
+      overflow: auto;
+      padding: 0.4rem;
+      white-space: normal;
+    }
   }
 
   // nice kooshy padding

--- a/app/assets/stylesheets/local/_settings.scss
+++ b/app/assets/stylesheets/local/_settings.scss
@@ -10,14 +10,7 @@ form.setting_form {
 
   #external_sql .control {
     pre {
-      background-color: $pre-bg;
-      border: 1px solid #ccc;
-      font-size: 8pt;
       height: 100px;
-      margin: 0 0 3px;
-      overflow: auto;
-      padding: 0.4rem;
-      white-space: normal;
     }
   }
 }

--- a/app/assets/stylesheets/local/_settings.scss
+++ b/app/assets/stylesheets/local/_settings.scss
@@ -19,9 +19,5 @@ form.setting_form {
       padding: 0.4rem;
       white-space: normal;
     }
-
-    a {
-      font-size: 9pt;
-    }
   }
 }

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -46,7 +46,7 @@ class ResponsesController < ApplicationController
         @selected_all_pages = params[:select_all_pages]
 
         @response_csv_export_options = ResponseCSVExportOptions.new
-        @odata_url = request.original_url.sub("/responses", "/odata/v1")
+        @response_odata_export_options = ResponseODataExportOptions.new(request_url: request.original_url)
 
         # render just the table if this is an ajax request
         render(partial: "table_only", locals: {responses: responses}) if request.xhr?

--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -46,6 +46,7 @@ class ResponsesController < ApplicationController
         @selected_all_pages = params[:select_all_pages]
 
         @response_csv_export_options = ResponseCSVExportOptions.new
+        @odata_url = request.original_url.sub("/responses", "/odata/v1")
 
         # render just the table if this is an ajax request
         render(partial: "table_only", locals: {responses: responses}) if request.xhr?

--- a/app/helpers/elmo_form_builder.rb
+++ b/app/helpers/elmo_form_builder.rb
@@ -19,6 +19,7 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
   # options[:data] - Data attributes that will be included with input tag
   # options[:unnamed] - Remove the name attribute for the tag so it doesn't show up in the submission data.
   # options[:step] - Step attribute for number fields.
+  # options[:value] - Value to use instead of loading from the DB.
 
   # The placeholder attribute is handled using I18n. See placeholder code below
 
@@ -145,7 +146,7 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
 
     # otherwise generate field based on type
     else
-      val = @object.send(field_name)
+      val = options.key?(:value) ? options[:value] : @object.send(field_name)
 
       # if field is read only, just show the value
       if options[:read_only]
@@ -204,6 +205,9 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
 
         when :textarea
           text_area(field_name, tag_options)
+
+        when :pre
+          @template.content_tag(:pre, val, tag_options)
 
         when :password
           # add 'text' class for legacy support

--- a/app/helpers/elmo_form_builder.rb
+++ b/app/helpers/elmo_form_builder.rb
@@ -20,6 +20,7 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
   # options[:unnamed] - Remove the name attribute for the tag so it doesn't show up in the submission data.
   # options[:step] - Step attribute for number fields.
   # options[:value] - Value to use instead of loading from the DB.
+  # options[:class] - Class string to append to the field.
 
   # The placeholder attribute is handled using I18n. See placeholder code below
 
@@ -184,7 +185,7 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
         tag_options = options.slice(:id, :data) # Include these attribs with all tags, if given.
 
         tag_options[:name] = nil if options[:unnamed]
-        tag_options[:class] = "form-control"
+        tag_options[:class] = "form-control #{options[:class] || ''}".strip
 
         placeholder_key = "activerecord.placeholders.#{@object.class.model_name.i18n_key}.#{field_name}"
         placeholder = I18n.t(placeholder_key, default: "")

--- a/app/helpers/elmo_form_builder.rb
+++ b/app/helpers/elmo_form_builder.rb
@@ -21,6 +21,7 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
   # options[:step] - Step attribute for number fields.
   # options[:value] - Value to use instead of loading from the DB.
   # options[:class] - Class string to append to the field.
+  # options[:copyable] - If true, will add 'Copy to Clipboard' button below the field.
 
   # The placeholder attribute is handled using I18n. See placeholder code below
 
@@ -43,6 +44,14 @@ class ElmoFormBuilder < ActionView::Helpers::FormBuilder
     wrapper_classes << options[:wrapper_class]
     wrapper_classes << "#{@object.class.model_name.param_key}_#{field_name}"
     wrapper_classes << "has-errors" if errors.present?
+
+    if options[:copyable]
+      text = I18n.t("layout.copy_to_clipboard")
+      options[:id] ||= "copy-value-#{field_name}"
+      options[:append] = @template.content_tag(:div, text, class: "btn btn-link btn-a",
+                                                           id: "copy-btn-#{field_name}",
+                                                           "data-clipboard-target": "##{options[:id]}")
+    end
 
     # get key chunks and render partial
     @template.render(partial: "layouts/elmo_form_field", locals: {

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -56,11 +56,11 @@ module ResponsesHelper
   end
 
   def export_dropdown_parent
-    link_to(t("response.export"), "#", id: "export-dropdown",
-                                       class: "dropdown-toggle",
-                                       role: "button",
-                                       "data-toggle": "dropdown",
-                                       "aria-haspopup": "true")
+    link_to(t("response.export.export"), "#", id: "export-dropdown",
+                                              class: "dropdown-toggle",
+                                              role: "button",
+                                              "data-toggle": "dropdown",
+                                              "aria-haspopup": "true")
   end
 
   def export_dropdown_children(responses)
@@ -68,10 +68,10 @@ module ResponsesHelper
                       "aria-labelledby": "export-dropdown") do
       [
         unless responses.empty?
-          link_to(t("response.export_to_csv"), "#", id: "export-csv-link",
+          link_to(t("response.export.to_csv"), "#", id: "export-csv-link",
                                                     class: "dropdown-item")
         end,
-        link_to(t("response.export_to_odata"), "#", id: "export-odata-link",
+        link_to(t("response.export.to_odata"), "#", id: "export-odata-link",
                                                     class: "dropdown-item")
       ].compact.reduce(:<<)
     end

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -46,12 +46,35 @@ module ResponsesHelper
       confirm: "response.bulk_destroy_confirm"
     )
 
-    if !responses.empty? && can?(:export, Response)
-      links << link_to(t("response.export_to_csv"), "#", id: "export-link")
-    end
+    links << export_dropdown(responses) if can?(:export, Response)
 
-    # return the assembled list of links
     links
+  end
+
+  def export_dropdown(responses)
+    [export_dropdown_parent, export_dropdown_children(responses)].reduce(:<<)
+  end
+
+  def export_dropdown_parent
+    link_to(t("response.export"), "#", id: "export-dropdown",
+                                       class: "dropdown-toggle",
+                                       role: "button",
+                                       "data-toggle": "dropdown",
+                                       "aria-haspopup": "true")
+  end
+
+  def export_dropdown_children(responses)
+    content_tag(:div, class: "dropdown-menu",
+                      "aria-labelledby": "export-dropdown") do
+      [
+        unless responses.empty?
+          link_to(t("response.export_to_csv"), "#", id: "export-csv-link",
+                                                    class: "dropdown-item")
+        end,
+        link_to(t("response.export_to_odata"), "#", id: "export-odata-link",
+                                                    class: "dropdown-item")
+      ].compact.reduce(:<<)
+    end
   end
 
   # takes a recent count (e.g. [5, "week"]) and translates it

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -40,15 +40,15 @@ module ResponsesHelper
   def responses_index_links(responses)
     links = []
 
-    if !responses.empty? && can?(:export, Response)
-      links << link_to(t("response.export_to_csv"), "#", id: "export-link")
-    end
-
     links << batch_op_link(
       name: t("response.bulk_destroy"),
       path: bulk_destroy_responses_path(search: params[:search]),
       confirm: "response.bulk_destroy_confirm"
     )
+
+    if !responses.empty? && can?(:export, Response)
+      links << link_to(t("response.export_to_csv"), "#", id: "export-link")
+    end
 
     # return the assembled list of links
     links

--- a/app/models/response_o_data_export_options.rb
+++ b/app/models/response_o_data_export_options.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Custom options for exporting responses via OData.
+class ResponseODataExportOptions
+  include ActiveModel::Model
+
+  attr_accessor :request_url, :api_url
+
+  def initialize(*args)
+    super
+    self.api_url = request_url.sub("/responses", "/odata/v1")
+  end
+end

--- a/app/views/responses/_export_csv_modal.html.erb
+++ b/app/views/responses/_export_csv_modal.html.erb
@@ -1,9 +1,9 @@
-<div class="modal fade" id="export-modal" tabindex="-1" role="dialog" aria-hidden="true">
+<div class="modal fade" id="export-csv-modal" tabindex="-1" role="dialog" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <%= elmo_form_for(@response_csv_export_options, url: responses_path(format: :csv), method: "get") do |f| %>
         <div class="modal-header">
-          <h4 class="modal-title"><%= t("response.export_to_csv") %></h4>
+          <h4 class="modal-title"><%= "#{t('response.export')}: #{t('response.export_to_csv')}" %></h4>
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         </div>
         <div class="modal-body">

--- a/app/views/responses/_export_csv_modal.html.erb
+++ b/app/views/responses/_export_csv_modal.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-content">
       <%= elmo_form_for(@response_csv_export_options, url: responses_path(format: :csv), method: "get") do |f| %>
         <div class="modal-header">
-          <h4 class="modal-title"><%= "#{t('response.export')}: #{t('response.export_to_csv')}" %></h4>
+          <h4 class="modal-title"><%= "#{t('response.export.export')}: #{t('response.export.to_csv')}" %></h4>
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
         </div>
         <div class="modal-body">

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -10,7 +10,8 @@
         <form>
           <div class="form-group">
             <label for="api-endpoint">API Endpoint</label>
-            <input type="text" disabled class="form-control" id="api-endpoint" value=<%= @odata_url %>>
+            <input type="text" class="form-control" id="api-endpoint" name="api-endpoint"
+                   disabled value=<%= @odata_url %>>
           </div>
         </form>
       </div>

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -6,14 +6,12 @@
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
       </div>
       <div class="modal-body">
-        <p><%= t("response.export.odata_prompt_html") %></p>
-        <form>
-          <div class="form-group">
-            <label for="api-endpoint"><%= t("response.export.odata_url_label") %></label>
-            <input type="text" class="form-control" id="api-endpoint" name="api-endpoint"
-                   disabled value=<%= @odata_url %>>
+        <%= elmo_form_for(@response_odata_export_options, url: "") do |f| %>
+          <div class="fields">
+            <p><%= t("response.export.odata_prompt_html") %></p>
+            <%= f.field(:api_url, type: :text, read_only: true) %>
           </div>
-        </form>
+        <% end %>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -9,7 +9,8 @@
         <%= elmo_form_for(@response_odata_export_options, url: "") do |f| %>
           <div class="fields">
             <p><%= t("response.export.odata_prompt_html") %></p>
-            <%= f.field(:api_url, type: :text, read_only: true) %>
+            <%= f.field(:api_url, type: :pre, class: "mb-1",
+              append: link_to(t("layout.select_all"), "#")) %>
           </div>
         <% end %>
       </div>

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -9,8 +9,8 @@
         <%= elmo_form_for(@response_odata_export_options, url: "") do |f| %>
           <div class="fields">
             <p><%= t("response.export.odata_prompt_html") %></p>
-            <%= f.field(:api_url, type: :pre, class: "mb-1",
-              append: link_to(t("layout.select_all"), "#")) %>
+            <%= f.field(:api_url, type: :pre, class: "mb-1", id: "copy-value",
+              append: content_tag(:div, t("layout.copy_to_clipboard"), class: "btn btn-link btn-a", id: "copy-btn", "data-clipboard-target": "#copy-value")) %>
           </div>
         <% end %>
       </div>

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -9,7 +9,7 @@
         <p><%= t("response.export.odata_prompt_html") %></p>
         <form>
           <div class="form-group">
-            <label for="api-endpoint">API Endpoint</label>
+            <label for="api-endpoint"><%= t("response.export.odata_url_label") %></label>
             <input type="text" class="form-control" id="api-endpoint" name="api-endpoint"
                    disabled value=<%= @odata_url %>>
           </div>

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -1,0 +1,24 @@
+<div class="modal fade" id="export-odata-modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title"><%= "#{t('response.export.export')}: #{t('response.export.to_odata')}" %></h4>
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p><%= t("response.export.odata_prompt_html") %></p>
+        <form>
+          <div class="form-group">
+            <label for="api-endpoint">API Endpoint</label>
+            <input type="text" disabled class="form-control" id="api-endpoint" value=<%= @odata_url %>>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">
+          <%= t("common.close") %>
+        </button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->

--- a/app/views/responses/_export_odata_modal.html.erb
+++ b/app/views/responses/_export_odata_modal.html.erb
@@ -9,8 +9,7 @@
         <%= elmo_form_for(@response_odata_export_options, url: "") do |f| %>
           <div class="fields">
             <p><%= t("response.export.odata_prompt_html") %></p>
-            <%= f.field(:api_url, type: :pre, class: "mb-1", id: "copy-value",
-              append: content_tag(:div, t("layout.copy_to_clipboard"), class: "btn btn-link btn-a", id: "copy-btn", "data-clipboard-target": "#copy-value")) %>
+            <%= f.field(:api_url, type: :pre, class: "mb-1", copyable: true) %>
           </div>
         <% end %>
       </div>

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= index_table(responses) %>
 
-<%= render("export_modal") %>
+<%= render("export_csv_modal") %>
 
 <%= javascript_doc_ready do %>
   ELMO.responseListView = new ELMO.Views.ResponseListView(<%=json(

--- a/app/views/responses/index.html.erb
+++ b/app/views/responses/index.html.erb
@@ -3,6 +3,7 @@
 <%= index_table(responses) %>
 
 <%= render("export_csv_modal") %>
+<%= render("export_odata_modal") %>
 
 <%= javascript_doc_ready do %>
   ELMO.responseListView = new ELMO.Views.ResponseListView(<%=json(

--- a/app/views/settings/_external_sql.html.erb
+++ b/app/views/settings/_external_sql.html.erb
@@ -1,2 +1,0 @@
-<pre><%= @external_sql %></pre>
-<%= link_to("Select All", "#") %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -53,7 +53,8 @@
     </div>
 
     <h2 class="mt-4"><%= t("activerecord.attributes.setting.external_sql") %></h2>
-    <%= f.field(:external_sql, partial: "external_sql") %>
+    <%= f.field(:external_sql, type: :pre, value: @external_sql,
+      append: link_to(t("layout.select_all"), "#")) %>
   <% end %>
 
   <div class="submit-buttons">

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -53,8 +53,8 @@
     </div>
 
     <h2 class="mt-4"><%= t("activerecord.attributes.setting.external_sql") %></h2>
-    <%= f.field(:external_sql, type: :pre, value: @external_sql,
-      append: link_to(t("layout.select_all"), "#")) %>
+    <%= f.field(:external_sql, type: :pre, value: @external_sql, id: "copy-value",
+      append: content_tag(:div, t("layout.copy_to_clipboard"), class: "btn btn-link btn-a", id: "copy-btn", "data-clipboard-target": "#copy-value")) %>
   <% end %>
 
   <div class="submit-buttons">

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -53,8 +53,7 @@
     </div>
 
     <h2 class="mt-4"><%= t("activerecord.attributes.setting.external_sql") %></h2>
-    <%= f.field(:external_sql, type: :pre, value: @external_sql, id: "copy-value",
-      append: content_tag(:div, t("layout.copy_to_clipboard"), class: "btn btn-link btn-a", id: "copy-btn", "data-clipboard-target": "#copy-value")) %>
+    <%= f.field(:external_sql, type: :pre, value: @external_sql, copyable: true) %>
   <% end %>
 
   <div class="submit-buttons">

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -9,6 +9,7 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.singular(/^(sms)es$/i, '\1')
   inflect.acronym("API")
   inflect.acronym("CSV")
+  inflect.acronym("URL")
 
   #   inflect.singular /^(ox)en/i, '\1'
   #   inflect.irregular 'person', 'people'

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -1721,7 +1721,9 @@ en:
   response:
     reviewed: "This response has been reviewed"
     edit_this_response: "Edit This Response"
-    export_to_csv: "Export to CSV Format"
+    export: "Export"
+    export_to_csv: "CSV Format"
+    export_to_odata: "OData via API"
     export_options:
       summary:
         zero: "No responses to be exported."

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -1721,9 +1721,11 @@ en:
   response:
     reviewed: "This response has been reviewed"
     edit_this_response: "Edit This Response"
-    export: "Export"
-    export_to_csv: "CSV Format"
-    export_to_odata: "OData via API"
+    export:
+      export: "Export"
+      to_csv: "CSV Format"
+      to_odata: "OData via API"
+      odata_prompt_html: "Use the NEMO API to access data using the OData standard. Read more about the API in the documentation."
     export_options:
       summary:
         zero: "No responses to be exported."

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -1727,7 +1727,6 @@ en:
       to_csv: "CSV Format"
       to_odata: "OData via API"
       odata_prompt_html: "Use the NEMO API to access data using the OData standard. You can copy this URL into your data processing software, such as Power BI. Read more about the API in the documentation."
-      odata_url_label: "API URL"
     export_options:
       summary:
         zero: "No responses to be exported."

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -1725,7 +1725,8 @@ en:
       export: "Export"
       to_csv: "CSV Format"
       to_odata: "OData via API"
-      odata_prompt_html: "Use the NEMO API to access data using the OData standard. Read more about the API in the documentation."
+      odata_prompt_html: "Use the NEMO API to access data using the OData standard. You can copy this URL into your data processing software, such as Power BI. Read more about the API in the documentation."
+      odata_url_label: "API URL"
     export_options:
       summary:
         zero: "No responses to be exported."

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -888,6 +888,7 @@ en:
     are_you_sure: "Are you sure?"
     change_language: "Change Language"
     created_by: "Created by"
+    copy_to_clipboard: "Copy to Clipboard"
     delete_warning: "Are you sure you want to permanently delete the %{obj_description}?"
     deselect_all: "Deselect All"
     loading: "Loading..."

--- a/spec/features/responses/csv_export_spec.rb
+++ b/spec/features/responses/csv_export_spec.rb
@@ -23,7 +23,8 @@ feature "responses csv export" do
   scenario "exporting csv" do
     visit(responses_path(params))
 
-    click_link("Export to CSV Format")
+    click_link("Export")
+    click_link("CSV Format")
     expect(page).to(have_content("#{Response.all.length} responses to be exported"))
 
     perform_enqueued_jobs do

--- a/spec/features/responses/odata_export_spec.rb
+++ b/spec/features/responses/odata_export_spec.rb
@@ -19,6 +19,6 @@ feature "responses odata export", js: true do
 
     click_link("Export")
     click_link("OData via API")
-    expect(page).to(have_selector(".widget .ro-val", text: %r{/odata/v1}))
+    expect(page).to(have_selector(".widget pre", text: %r{/odata/v1}))
   end
 end

--- a/spec/features/responses/odata_export_spec.rb
+++ b/spec/features/responses/odata_export_spec.rb
@@ -19,6 +19,6 @@ feature "responses odata export", js: true do
 
     click_link("Export")
     click_link("OData via API")
-    expect(page).to(have_field("api-endpoint", with: %r{/odata/v1}, disabled: true))
+    expect(page).to(have_selector(".widget .ro-val", text: %r{/odata/v1}))
   end
 end

--- a/spec/features/responses/odata_export_spec.rb
+++ b/spec/features/responses/odata_export_spec.rb
@@ -21,7 +21,7 @@ feature "responses odata export", js: true do
     click_link("OData via API")
     expect(page).to(have_selector(".widget pre", text: %r{/odata/v1}))
 
-    find("#copy-btn").click
+    find("#copy-btn-api_url").click
     expect(clipboard).to match(%r{/odata/v1})
   end
 end

--- a/spec/features/responses/odata_export_spec.rb
+++ b/spec/features/responses/odata_export_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "responses odata export", js: true do
+  let(:user) { create(:user) }
+  let(:params) do
+    {
+      locale: "en",
+      mode: "m",
+      mission_name: get_mission.compact_name
+    }
+  end
+
+  before { login(user) }
+
+  scenario "exporting odata" do
+    visit(responses_path(params))
+
+    click_link("Export")
+    click_link("OData via API")
+    expect(page).to(have_field("api-endpoint", with: %r{/odata/v1}, disabled: true))
+  end
+end

--- a/spec/features/responses/odata_export_spec.rb
+++ b/spec/features/responses/odata_export_spec.rb
@@ -20,5 +20,8 @@ feature "responses odata export", js: true do
     click_link("Export")
     click_link("OData via API")
     expect(page).to(have_selector(".widget pre", text: %r{/odata/v1}))
+
+    find("#copy-btn").click
+    expect(clipboard).to match(%r{/odata/v1})
   end
 end

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -151,4 +151,18 @@ module FeatureSpecHelpers
     yield
     ActionMailer::Base.deliveries[old_count..-1] || []
   end
+
+  # Get the contents of the user's clipboard.
+  def clipboard
+    page.driver.browser.execute_cdp(
+      "Browser.grantPermissions",
+      origin: page.server_url, permissions: %w[clipboardReadWrite clipboardSanitizedWrite]
+    )
+    # Unset the clipboard after reading, for purity.
+    page.evaluate_script(%{
+      text = navigator.clipboard.readText();
+      navigator.clipboard.writeText('');
+      text;
+    })
+  end
 end


### PR DESCRIPTION
### User-facing changes

- Added Bootstrap "Export" dropdown to Responses index_links
- Added OData export modal that matches existing UI elements
- Used "Copy to Clipboard" functionality for existing Settings `external_sql`

### Refactors

- Updated elmo form logic so we can easily reuse `:copyable` and `:pre`

<img width="786" alt="Screen Shot 2020-06-04 at 22 07 36" src="https://user-images.githubusercontent.com/2047062/83839064-d61e0280-a6af-11ea-9afa-9a1792663603.png">
