### PR TITLE
10823 fix server 500 with unicode usernames

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem "webpacker", "~> 4.2"
 
 # Authz and Authn
 gem "activerecord-session_store", "~> 1.1.1"
-gem "authlogic", "~> 4.4.2"
+gem "authlogic", "~> 6.1"
 gem "cancancan", "~> 2.3.0"
 gem "draper-cancancan", "~> 1.1"
 gem "scrypt", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,11 +115,11 @@ GEM
       activesupport (>= 3.0.0)
     ast (2.4.1)
     attribute_normalizer (1.2.0)
-    authlogic (4.4.2)
-      activerecord (>= 4.2, < 5.3)
-      activesupport (>= 4.2, < 5.3)
+    authlogic (6.1.0)
+      activemodel (>= 5.2, < 6.1)
+      activerecord (>= 5.2, < 6.1)
+      activesupport (>= 5.2, < 6.1)
       request_store (~> 1.0)
-      scrypt (>= 1.2, < 4.0)
     autoprefixer-rails (9.5.0)
       execjs
     awesome_print (1.6.1)
@@ -434,7 +434,7 @@ GEM
       tilt
     recaptcha (0.4.0)
     regexp_parser (1.7.1)
-    request_store (1.4.1)
+    request_store (1.5.0)
       rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -597,7 +597,7 @@ DEPENDENCIES
   api-pagination (~> 4.1.1)
   assert_difference (~> 1.0.0)
   attribute_normalizer (~> 1.2.0)
-  authlogic (~> 4.4.2)
+  authlogic (~> 6.1)
   awesome_print (~> 1.6.1)
   axlsx (~> 2.1.1)!
   axlsx_rails (~> 0.5.0)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,7 +102,7 @@ class User < ApplicationRecord
   validate(:must_have_password_on_enter)
   validate(:password_reset_cant_be_email_if_no_email)
   validate(:no_duplicate_assignments)
-  validates(:login, format: {with: /\A[a-zA-Z0-9\._]+\z/}, uniqueness: true)
+  validates(:login, format: {with: /\A[[:word:].]+\z/}, uniqueness: true)
   validates(:email, format: {with: /@/}, length: {maximum: 100}, allow_blank: true)
 
   # This validation causes issues when deleting missions,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,13 +82,6 @@ class User < ApplicationRecord
     c.disable_perishable_token_maintenance = true
     c.perishable_token_valid_for = 1.week
     c.logged_in_timeout(SESSION_TIMEOUT)
-
-    # Authlogic model validation is deprecated in 4.4.0
-    # Will be removed entirely from 5.0.0
-    # These fields are manually validated below
-    c.validate_email_field = false
-    c.validate_login_field = false
-    c.validate_password_field = false
   end
 
   after_initialize(:set_default_pref_lang)

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -709,7 +709,7 @@ en:
         body: "Enter the body of the message."
       user:
         name: "The user's full name. Example: 'John Doe' or 'Team 1.1'"
-        login: "The username will be used to log in. It may contain only unaccented letters, numbers, periods, and underscores."
+        login: "The username will be used to log in. It may contain only letters, numbers, periods, and underscores."
         phone: "Phone number must include the country code. Example: +25680344523"
         phone2: "Phone number must include the country code. Example: +25680344523"
         admin: "Whether this user is a system-wide administrator. You can control per-mission permissions using the fields below."
@@ -865,7 +865,7 @@ en:
             assignments:
               cant_be_empty_if_not_admin: "At least one assignment is required if user is not an admin."
             login:
-              invalid: "Please use only unaccented letters, numbers, periods, and underscores."
+              invalid: "Please use only letters, numbers, periods, and underscores."
             reset_password_method:
               cant_passwd_email: "Not allowed unless an email address is provided."
         user_import:

--- a/spec/jobs/tabular_import_operation_job_spec.rb
+++ b/spec/jobs/tabular_import_operation_job_spec.rb
@@ -27,7 +27,7 @@ describe TabularImportOperationJob do
       expect(operation.completed?).to be(true)
       expect(operation.failed?).to be(true)
       expect(operation.job_error_report).to match("* Row 2: Main Phone: Please enter at least 9 digits."\
-        "\n* Row 3: Username: Please use only unaccented letters, numbers, periods, and underscores.")
+        "\n* Row 3: Username: Please use only letters, numbers, periods, and underscores.")
     end
   end
 end

--- a/spec/models/user_import_spec.rb
+++ b/spec/models/user_import_spec.rb
@@ -149,7 +149,7 @@ describe UserImport do
       expect(import).not_to be_succeeded
       expect(run_errors).to eq([
         "Row 2: Main Phone: Please enter at least 9 digits.",
-        "Row 3: Username: Please use only unaccented letters, numbers, periods, and underscores."
+        "Row 3: Username: Please use only letters, numbers, periods, and underscores."
       ])
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -212,6 +212,7 @@ describe User do
     end
 
     it "should not allow invalid chars" do
+      # TODO
       ["foo bar", "foo✓bar", "foébar", "foo'bar"].each do |login|
         user = build(:user, login: login)
         expect(user).not_to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -211,12 +211,20 @@ describe User do
       end
     end
 
-    it "should not allow invalid chars" do
-      # TODO
-      ["foo bar", "foo✓bar", "foébar", "foo'bar"].each do |login|
+    it "should allow unicode word chars" do
+      %w[foo_bar.baz foébar テスト].each do |login|
+        user = build(:user, login: login)
+        expect(user).to be_valid, "Expected login to be allowed: #{login}"
+      end
+    end
+
+    it "should disallow unicode non-word chars" do
+      ["foo bar", "foo\nbar", "foo'bar", "foo✓bar", "foo😂bar", "foo\u00A0bar"].each do |login|
         user = build(:user, login: login)
         expect(user).not_to be_valid
-        expect(user.errors[:login].join).to match(/letters, numbers, periods/)
+        # TODO: Update error messages.
+        expect(user.errors[:login].join)
+          .to match(/letters, numbers, periods/), "Expected login to be disallowed: #{login}"
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -212,7 +212,7 @@ describe User do
     end
 
     it "should allow unicode word chars" do
-      %w[foo_bar.baz foébar テスト].each do |login|
+      %w[foo_bar.baz 123 foébar テスト].each do |login|
         user = build(:user, login: login)
         expect(user).to be_valid, "Expected login to be allowed: #{login}"
       end

--- a/spec/requests/basic_authentication_spec.rb
+++ b/spec/requests/basic_authentication_spec.rb
@@ -3,13 +3,24 @@
 require "rails_helper"
 
 describe "basic authentication for xml requests" do
+  let(:form_list) { "/m/#{get_mission.compact_name}/formList" }
+
   before do
     @user = create(:user)
   end
 
   context "when not already logged in" do
+    # `fooé:bar` base64 encoded with Latin-1 output (instead of UTF-8).
+    let(:bad_headers) { {"HTTP_AUTHORIZATION" => "Basic Zm9v6TpiYXI="} }
+
     it "should be required" do
-      get "/m/#{get_mission.compact_name}/formList"
+      get form_list
+      assert_response :unauthorized
+      expect(response.headers["WWW-Authenticate"]).to eq('Basic realm="Application"')
+    end
+
+    it "should gracefully handle invalid Latin-1 encoding" do
+      get form_list, headers: bad_headers
       assert_response :unauthorized
       expect(response.headers["WWW-Authenticate"]).to eq('Basic realm="Application"')
     end
@@ -21,11 +32,8 @@ describe "basic authentication for xml requests" do
     end
 
     it "should not be required" do
-      get "/m/#{get_mission.compact_name}/formList"
+      get form_list
       assert_response :success
     end
   end
-
-  # TODO: Spec for username string encoding.
-  #   encode('iso8859-1') for Latin-1 like ODK Collect sends.
 end

--- a/spec/requests/basic_authentication_spec.rb
+++ b/spec/requests/basic_authentication_spec.rb
@@ -25,4 +25,7 @@ describe "basic authentication for xml requests" do
       assert_response :success
     end
   end
+
+  # TODO: Spec for username string encoding.
+  #   encode('iso8859-1') for Latin-1 like ODK Collect sends.
 end


### PR DESCRIPTION
Collect does not yet support sending UTF-8 encoded Basic auth, but [is open to adding support](https://forum.getodk.org/t/support-for-special-characters-in-usernames-basic-auth/27696/4) if we submit a PR. Either way, we should not throw up a 500 error if a username is submitted with invalid encoding.

This PR
1. converts the input to UTF-8 if necessary,
2. allows a broader set of characters to be in the username (specifically `[:word:]` and `.`), and
3. properly returns 401 if the username doesn't exist, regardless of encoding.

Do you agree this is a reasonable route to go? If so, TODO:
- [x] Add spec for Basic auth flow
- [x] Update a couple of error message strings to reflect the newly allowable characters