### PR TITLE
10920: Fix integers missing from truncated CSV export

### DIFF
--- a/app/models/results/csv/answer_processor.rb
+++ b/app/models/results/csv/answer_processor.rb
@@ -44,6 +44,10 @@ module Results
         row["question_code"]
       end
 
+      def qtype
+        row["qtype_name"]
+      end
+
       def select_cols?
         row["answer_option_name"].present? || row["choice_option_name"].present?
       end
@@ -84,13 +88,14 @@ module Results
       # Performance-critical; try to do everything in-place.
       # We do this with loops instead of regexps b/c regexps are slow.
       def normalize_value(str)
-        if long_text_behavior == "exclude"
+        long_text = qtype == "long_text"
+        if long_text && long_text_behavior == "exclude"
           str.slice!(0..-1)
           return
         end
         convert_unix_line_endings_to_windows(str)
         convert_mac_line_endings_to_windows(str)
-        convert_long_text(str)
+        convert_long_text(str) if long_text
       end
 
       # Insert \r before any \ns without \rs before

--- a/app/models/results/csv/answer_query.rb
+++ b/app/models/results/csv/answer_query.rb
@@ -37,6 +37,7 @@ module Results
             #{choice_option_name} AS choice_option_name,
             choice_options.value AS choice_option_value,
             questions.code AS question_code,
+            questions.qtype_name AS qtype_name,
             #{option_level_name} AS option_level_name
         SQL
       end

--- a/spec/fixtures/response_csv/truncated_values.csv
+++ b/spec/fixtures/response_csv/truncated_values.csv
@@ -1,2 +1,2 @@
-ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,TextQ1,TextQ2
-*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00-06,false,,0,foo,foo ba
+ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,LongTextQ2,TextQ1
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00-06,false,,0,long t,regular text preserved

--- a/spec/models/results/csv/answer_processor_spec.rb
+++ b/spec/models/results/csv/answer_processor_spec.rb
@@ -135,7 +135,15 @@ describe Results::Csv::AnswerProcessor do
     it "excludes long text" do
       expect(buffer).to receive(:write).with("Q1", "")
       processor.process(
-        {"question_code" => "Q1", "value" => +"12345"},
+        {"question_code" => "Q1", "value" => +"12345", "qtype_name" => "long_text"},
+        long_text_behavior: "exclude"
+      )
+    end
+
+    it "doesn't exclude regular text" do
+      expect(buffer).to receive(:write).with("Q1", "12345")
+      processor.process(
+        {"question_code" => "Q1", "value" => +"12345", "qtype_name" => "text"},
         long_text_behavior: "exclude"
       )
     end
@@ -143,7 +151,7 @@ describe Results::Csv::AnswerProcessor do
     it "truncates after max characters" do
       expect(buffer).to receive(:write).with("Q1", "1234567890ab")
       processor.process(
-        {"question_code" => "Q1", "value" => +"1234567890abcde"},
+        {"question_code" => "Q1", "value" => +"1234567890abcde", "qtype_name" => "long_text"},
         long_text_behavior: "truncate"
       )
     end
@@ -151,7 +159,7 @@ describe Results::Csv::AnswerProcessor do
     it "truncates after max newlines (below max)" do
       expect(buffer).to receive(:write).with("Q1", "12\r\n345")
       processor.process(
-        {"question_code" => "Q1", "value" => +"12\r345"},
+        {"question_code" => "Q1", "value" => +"12\r345", "qtype_name" => "long_text"},
         long_text_behavior: "truncate"
       )
     end
@@ -159,7 +167,7 @@ describe Results::Csv::AnswerProcessor do
     it "truncates after max newlines (above max)" do
       expect(buffer).to receive(:write).with("Q1", "12\r\n34")
       processor.process(
-        {"question_code" => "Q1", "value" => +"12\n34\n5"},
+        {"question_code" => "Q1", "value" => +"12\n34\n5", "qtype_name" => "long_text"},
         long_text_behavior: "truncate"
       )
     end
@@ -167,7 +175,7 @@ describe Results::Csv::AnswerProcessor do
     it "counts each CRLF as a single line" do
       expect(buffer).to receive(:write).with("Q1", "\r\nfoo")
       processor.process(
-        {"question_code" => "Q1", "value" => +"\r\nfoo\r\nbar\r\n"},
+        {"question_code" => "Q1", "value" => +"\r\nfoo\r\nbar\r\n", "qtype_name" => "long_text"},
         long_text_behavior: "truncate"
       )
     end
@@ -175,7 +183,7 @@ describe Results::Csv::AnswerProcessor do
     it "handles a dangling CR at end of truncated string" do
       expect(buffer).to receive(:write).with("Q1", "1234567890a")
       processor.process(
-        {"question_code" => "Q1", "value" => +"1234567890a\r\nb"},
+        {"question_code" => "Q1", "value" => +"1234567890a\r\nb", "qtype_name" => "long_text"},
         long_text_behavior: "truncate"
       )
     end

--- a/spec/models/results/csv/generator_spec.rb
+++ b/spec/models/results/csv/generator_spec.rb
@@ -302,12 +302,12 @@ describe Results::Csv::Generator, :reset_factory_sequences do
 
   context "with long_text_behavior" do
     let(:options) { {long_text_behavior: "truncate"} }
-    let(:form) { create(:form, question_types: %w[text text]) }
+    let(:form) { create(:form, question_types: %w[text long_text]) }
 
     before do
       stub_const(Results::Csv::AnswerProcessor, "MAX_CHARACTERS", 6)
       Timecop.freeze(submission_time) do
-        create_response(form: form, answer_values: ["foo", "foo bar baz"])
+        create_response(form: form, answer_values: ["regular text preserved", "long text truncated"])
       end
     end
 


### PR DESCRIPTION
Detect `long_text` answers and only truncate those vals. Somehow this was completely overlooked when I originally implemented it and **every** `value` field was truncated 😊 

Will hotfix onto health.