### PR TITLE
10958: Set metadata so cloud attachments download properly

### DIFF
--- a/app/jobs/response_csv_export_operation_job.rb
+++ b/app/jobs/response_csv_export_operation_job.rb
@@ -29,6 +29,13 @@ class ResponseCsvExportOperationJob < OperationJob
     attachment = Results::Csv::Generator.new(responses, options: options).export
     timestamp = Time.current.to_s(:filename_datetime)
     attachment_download_name = "#{mission.compact_name}-responses-#{timestamp}.csv"
-    {attachment: attachment, attachment_download_name: attachment_download_name}
+    {
+      attachment: attachment,
+      # Metadata for disk storage.
+      attachment_download_name: attachment_download_name,
+      # Metadata for cloud storage.
+      attachment_file_name: attachment_download_name,
+      attachment_content_type: "text/csv"
+    }
   end
 end

--- a/app/models/operation.rb
+++ b/app/models/operation.rb
@@ -54,7 +54,14 @@ class Operation < ApplicationRecord
 
   belongs_to :creator, class_name: "User"
 
-  has_attached_file :attachment
+  has_attached_file :attachment,
+    fog_file: lambda { |attachment|
+      {
+        # Set some metadata so files download instead of rendering in browser.
+        content_type: attachment.content_type,
+        content_disposition: "attachment; filename=#{attachment.original_filename}"
+      }
+    }
   do_not_validate_attachment_file_type :attachment
 
   def name


### PR DESCRIPTION
When using cloud storage, now instead of rendering a file named `20200729-9391-lk1wg1` in the browser, it downloads a file named `fakemission7718-responses-2020-07-30-0403.csv` as expected.