### PR TITLE
10997 map performance

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -57,6 +57,12 @@ class WelcomeController < ApplicationController
     ].join("-")
   end
 
+  def cache_key_with_current_user
+    # User gets updated on every request, so don't include timestamp.
+    # Their role is already part of the Assignment cache in the cache_key.
+    @cache_key_with_current_user ||= "#{cache_key}-users/#{current_user.id}"
+  end
+
   def dashboard_index
     # we need to check for a cache fragment here because some of the below fetches are not lazy
     @cache_key = cache_key
@@ -80,7 +86,7 @@ class WelcomeController < ApplicationController
 
       # These two SQL queries are both very expensive.
       @location_answers, @location_answers_count =
-        Rails.cache.fetch(cache_key + "/location_answers") do
+        Rails.cache.fetch(cache_key_with_current_user + "/location_answers") do
           [
             location_answers.pluck(:response_id, :latitude, :longitude),
             location_answers.total_entries


### PR DESCRIPTION
Cache the `location_answers` queries for the map. In practice, reduces GW homepage load time from 6.0 => 0.3 seconds (20x improvement :rocket:)

Real cache key example: `en-response/mission-0a448e11-5959-4362-9e5c-8b92151ed5d6/132-20200813173101-assignment/mission-0a448e11-5959-4362-9e5c-8b92151ed5d6/34-20200813173038-users/8dcd65d0-f624-4845-b1bf-7714edef09cd/location_answers`