### PR TITLE
10996 fix blank lists after searching

### DIFF
--- a/app/assets/javascripts/views/search_form_view.js
+++ b/app/assets/javascripts/views/search_form_view.js
@@ -24,7 +24,10 @@ ELMO.Views.SearchFormView = class SearchFormView extends ELMO.Views.ApplicationV
     return $('#search-help-modal').modal('show');
   }
 
-  // Add or replace the specified search qualifier
+  /**
+   * Add or replace the specified search qualifier.
+   * @deprecated - Use the newer Filters#submitSearch method instead.
+   */
   setQualifier(qualifier, val) {
     const search_box = this.$('.search-str');
     let current_search = search_box.val();

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -34,7 +34,7 @@ module FormsHelper
       if (count = form.responses_count).zero?
         0
       else
-        link_to(count, responses_path(search: "form:\"#{form.name}\""))
+        link_to(count, responses_path(search: "form-id:\"#{form.id}\""))
       end
     when "downloads" then form.downloads || 0
     when "smsable" then tbool(form.smsable?)

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -25,4 +25,8 @@ module ReportsHelper
       javascript_tag('if (typeof(google) != "undefined")
         google.load("visualization", "1", {packages:["corechart"]});')
   end
+
+  def shortcode_map(response_ids)
+    Response.where(id: response_ids).pluck(:id, :shortcode).to_h
+  end
 end

--- a/app/javascript/components/Filters/__snapshots__/component.test.js.snap
+++ b/app/javascript/components/Filters/__snapshots__/component.test.js.snap
@@ -1,93 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`integration navigates on apply advanced search 1`] = `[MockFunction]`;
-
-exports[`integration navigates on apply advanced search 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A1%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20something%20else",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+exports[`integration navigates on apply advanced search 1`] = `
+Array [
+  "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A1%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20something%20else",
+]
 `;
 
-exports[`integration navigates on apply form filter 1`] = `[MockFunction]`;
-
-exports[`integration navigates on apply form filter 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?search=form-id%3A%281%29%20reviewed%3A1%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20query",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+exports[`integration navigates on apply form filter 1`] = `
+Array [
+  "?search=form-id%3A%281%29%20reviewed%3A1%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20query",
+]
 `;
 
-exports[`integration navigates on apply question filter 1`] = `[MockFunction]`;
-
-exports[`integration navigates on apply question filter 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A1%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20query",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+exports[`integration navigates on apply question filter 1`] = `
+Array [
+  "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A1%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20query",
+]
 `;
 
-exports[`integration navigates on apply reviewed filter 1`] = `[MockFunction]`;
-
-exports[`integration navigates on apply reviewed filter 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A0%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20query",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+exports[`integration navigates on apply reviewed filter 1`] = `
+Array [
+  "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A0%20submitter-id%3A%28B%29%20group-id%3A%28B%29%20query",
+]
 `;
 
-exports[`integration navigates on apply submitter filter 1`] = `[MockFunction]`;
-
-exports[`integration navigates on apply submitter filter 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A1%20submitter-id%3A%28A%29%20group-id%3A%28A%29%20query",
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+exports[`integration navigates on apply submitter filter 1`] = `
+Array [
+  "?search=form-id%3A%282%29%20%7BOne%7D%3A%225%22%20reviewed%3A1%20submitter-id%3A%28A%29%20group-id%3A%28A%29%20query",
+]
 `;
 
 exports[`renders as expected (other page) 1`] = `

--- a/app/javascript/components/Filters/__snapshots__/utils.test.js.snap
+++ b/app/javascript/components/Filters/__snapshots__/utils.test.js.snap
@@ -20,52 +20,28 @@ exports[`gets item name (found) 1`] = `"One"`;
 
 exports[`gets item name (not found) 1`] = `"Unknown"`;
 
-exports[`submits searches 1`] = `[MockFunction]`;
+exports[`submits searches 1`] = `Array []`;
 
 exports[`submits searches 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?foo=bar&search=foo",
-    ],
+Array [
+  Array [
+    "?foo=bar&search=foo",
   ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+]
 `;
 
 exports[`submits searches 3`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "?foo=bar",
-    ],
+Array [
+  Array [
+    "?foo=bar",
   ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+]
 `;
 
 exports[`submits searches 4`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "/pathname",
-    ],
+Array [
+  Array [
+    "/pathname",
   ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
+]
 `;

--- a/app/javascript/components/Filters/component.test.js
+++ b/app/javascript/components/Filters/component.test.js
@@ -111,13 +111,13 @@ describe('integration', () => {
 
   it('navigates on apply advanced search', () => {
     wrapper.find('.search-str').simulate('change', { target: { value: 'something else' } });
-
     expectLocationToChangeOnClick(wrapper.find('Button.btn-advanced-search'));
   });
 });
 
 function expectLocationToChangeOnClick(element) {
-  expect(window.location.assign).toMatchSnapshot();
+  expect(window.location.assign.mock.calls.length).toBe(0);
   element.simulate('click');
-  expect(window.location.assign).toMatchSnapshot();
+  expect(window.location.assign.mock.calls.length).toBe(1);
+  expect(window.location.assign.mock.calls[0]).toMatchSnapshot();
 }

--- a/app/javascript/components/Filters/component.test.js
+++ b/app/javascript/components/Filters/component.test.js
@@ -78,18 +78,14 @@ describe('integration', () => {
     // Call prop directly since Select2 is stubbed out.
     overlay.find('Select2').prop('onSelect')({ target: { value: defaultProps.filtersStore.allForms[0].id } });
 
-    expect(window.location.assign).toMatchSnapshot();
-    overlay.find('Button.btn-apply').simulate('click');
-    expect(window.location.assign).toMatchSnapshot();
+    expectLocationToChangeOnClick(overlay.find('Button.btn-apply'));
   });
 
   it('navigates on apply question filter', () => {
     wrapper.find('Button#question-filter').simulate('click');
     const overlay = quietMount(wrapper.find('OverlayTrigger#question-filter').prop('overlay'));
 
-    expect(window.location.assign).toMatchSnapshot();
-    overlay.find('Button.btn-apply').simulate('click');
-    expect(window.location.assign).toMatchSnapshot();
+    expectLocationToChangeOnClick(overlay.find('Button.btn-apply'));
   });
 
   it('navigates on apply reviewed filter', () => {
@@ -97,9 +93,7 @@ describe('integration', () => {
     const overlay = quietMount(wrapper.find('OverlayTrigger#reviewed-filter').prop('overlay'));
     overlay.find('#no').simulate('click');
 
-    expect(window.location.assign).toMatchSnapshot();
-    overlay.find('Button.btn-apply').simulate('click');
-    expect(window.location.assign).toMatchSnapshot();
+    expectLocationToChangeOnClick(overlay.find('Button.btn-apply'));
   });
 
   it('navigates on apply submitter filter', () => {
@@ -112,16 +106,18 @@ describe('integration', () => {
       overlay.find(`Select2#${type}`).prop('onSelect')({ params: { data: { id, text: name } } });
     });
 
-    expect(window.location.assign).toMatchSnapshot();
-    overlay.find('Button.btn-apply').simulate('click');
-    expect(window.location.assign).toMatchSnapshot();
+    expectLocationToChangeOnClick(overlay.find('Button.btn-apply'));
   });
 
   it('navigates on apply advanced search', () => {
     wrapper.find('.search-str').simulate('change', { target: { value: 'something else' } });
 
-    expect(window.location.assign).toMatchSnapshot();
-    wrapper.find('Button.btn-advanced-search').simulate('click');
-    expect(window.location.assign).toMatchSnapshot();
+    expectLocationToChangeOnClick(wrapper.find('Button.btn-advanced-search'));
   });
 });
+
+function expectLocationToChangeOnClick(element) {
+  expect(window.location.assign).toMatchSnapshot();
+  element.simulate('click');
+  expect(window.location.assign).toMatchSnapshot();
+}

--- a/app/javascript/components/Filters/utils.js
+++ b/app/javascript/components/Filters/utils.js
@@ -114,13 +114,15 @@ export function getFilterString({
 }
 
 /**
- * Reload the page with the given search.
+ * Reload the page with the given search,
+ * resetting the page number.
  */
 export function submitSearch(filterString) {
   const parsed = queryString.parse(window.location.search);
-  // The `search` query param will be removed from the URL if it's `undefined`.
+  // Params will be removed from the URL if `undefined`.
   const search = filterString || undefined;
-  const params = queryString.stringify({ ...parsed, search });
+  const page = undefined;
+  const params = queryString.stringify({ ...parsed, search, page });
 
   window.location.assign(params
     ? `?${params}`

--- a/app/javascript/components/Filters/utils.test.js
+++ b/app/javascript/components/Filters/utils.test.js
@@ -65,19 +65,19 @@ it('gets filter string (all filters)', () => {
 
 it('submits searches', () => {
   window.location.search = '?foo=bar';
-  expect(window.location.assign).toMatchSnapshot();
+  expect(window.location.assign.mock.calls).toMatchSnapshot();
 
   submitSearch('foo');
-  expect(window.location.assign).toMatchSnapshot();
+  expect(window.location.assign.mock.calls).toMatchSnapshot();
 
   window.location.assign.mockClear();
   submitSearch(null);
-  expect(window.location.assign).toMatchSnapshot();
+  expect(window.location.assign.mock.calls).toMatchSnapshot();
 
   window.location.assign.mockClear();
   window.location.search = '?';
   submitSearch(null);
-  expect(window.location.assign).toMatchSnapshot();
+  expect(window.location.assign.mock.calls).toMatchSnapshot();
 });
 
 it('checks if param is truthy', () => {

--- a/app/javascript/components/Filters/utils.test.js
+++ b/app/javascript/components/Filters/utils.test.js
@@ -64,7 +64,8 @@ it('gets filter string (all filters)', () => {
 });
 
 it('submits searches', () => {
-  window.location.search = '?foo=bar';
+  // Page should go away after search, but other params should pass through.
+  window.location.search = '?foo=bar&page=2';
   expect(window.location.assign.mock.calls).toMatchSnapshot();
 
   submitSearch('foo');

--- a/app/views/reports/standard_form_report/_full_width_summary_row.html.erb
+++ b/app/views/reports/standard_form_report/_full_width_summary_row.html.erb
@@ -12,10 +12,11 @@
     </td>
   </tr>
 <% else %>
+  <% shortcodes = shortcode_map(summary.items.map(&:response_id)) %>
   <% summary.items.each do |item| %>
     <tr class="summary">
       <td colspan="<%= result_cols + 2 %>">
-        <%= render("reports/standard_form_report/item", item: item) %>
+        <%= render("reports/standard_form_report/item", item: item, shortcode: shortcodes[item.response_id]) %>
       </td>
       <%= render("reports/standard_form_report/reference", summary: summary) %>
     </tr>

--- a/app/views/reports/standard_form_report/_item.html.erb
+++ b/app/views/reports/standard_form_report/_item.html.erb
@@ -6,7 +6,7 @@
   <% if item.submitter_name.present? %>
     <div class="by-at">
       <%= t("report/report.submitted_by_at", user: item.submitter_name, datetime: item.created_at) %>,
-      <a href="<%= responses_path(item.response_id) %>">
+      <a href="<%= response_path(item.response_id) %>">
         <%= t("report/report.view_response", id: item.response_id) %>
       </a>
     </div>

--- a/app/views/reports/standard_form_report/_item.html.erb
+++ b/app/views/reports/standard_form_report/_item.html.erb
@@ -6,8 +6,8 @@
   <% if item.submitter_name.present? %>
     <div class="by-at">
       <%= t("report/report.submitted_by_at", user: item.submitter_name, datetime: item.created_at) %>,
-      <a href="<%= response_path(item.response_id) %>">
-        <%= t("report/report.view_response", id: item.response_id) %>
+      <a href="<%= response_path(shortcode) %>">
+        <%= t("report/report.view_response", id: shortcode) %>
       </a>
     </div>
   <% end %>

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -958,14 +958,14 @@ en:
           zero:  "No Questions found"
           one:   "Displaying <b>1</b> Question"
           other: "Displaying <b>all %{count}</b> Questions"
-          multi_page_html: "Displaying Questions <b>%{from} - %{to}</b> of <b>%{count}</b> in total"
+        multi_page_html: "Displaying Questions <b>%{from} - %{to}</b> of <b>%{count}</b> in total"
     questioning: # should be same as question
       page_entries_info:
         single_page_html:
           zero:  "No Questions found"
           one:   "Displaying <b>1</b> Question"
           other: "Displaying <b>all %{count}</b> Questions"
-          multi_page_html: "Displaying Questions <b>%{from} - %{to}</b> of <b>%{count}</b> in total"
+        multi_page_html: "Displaying Questions <b>%{from} - %{to}</b> of <b>%{count}</b> in total"
     report/report:
       page_entries_info:
         single_page_html:


### PR DESCRIPTION
Motivation:
- Previously, `page` was not reset when doing a search with the React search filter component. If you were on page 2 and searched for something that only had 1 page of results, you'd see a **blank** page saying e.g. "showing all 8 questions".

Core changes:
- Reset `page` on search
- Clean up messy snapshot tests a bit

Additional tweaks:
- Link to responses using the React search UI (`form-id:`) instead of textbox (`form:`)
- Fix `ActionController::UnknownFormat` when clicking standard from report links to responses
