### PR TITLE
9948 clear level_names on save

### DIFF
--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -355,6 +355,7 @@ class OptionSet < ApplicationRecord
   def normalize_fields
     self.name = name.strip
     self.allow_coordinates = false unless geographic?
+    self.level_names = nil unless multilevel?
     true
   end
 

--- a/db/migrate/20200817185105_nullify_level_names_for_single_level.rb
+++ b/db/migrate/20200817185105_nullify_level_names_for_single_level.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Somehow at least one option set got assigned level_names without actually being multilevel.
+# Normalize any other instances that may exist.
+class NullifyLevelNamesForSingleLevel < ActiveRecord::Migration[5.2]
+  def up
+    OptionSet.all.each do |option_set|
+      next if option_set.multilevel? || option_set.level_names.nil?
+      puts "Found invalid option_set #{option_set.id}"
+      option_set.update!(level_names: nil)
+    end
+  end
+
+  def down
+    # No worries.
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_014859) do
+ActiveRecord::Schema.define(version: 2020_08_17_185105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/models/option_set_import_spec.rb
+++ b/spec/models/option_set_import_spec.rb
@@ -134,7 +134,11 @@ describe OptionSets::Import do
     option_set = import.option_set
     expect(option_set).to have_attributes(name: "MySet", geographic?: false, mission: mission)
     expect(option_set.levels).to be_nil
-    expect(option_set.level_names).to include("en" => "Province")
+    if option_set.multilevel?
+      expect(option_set.level_names).to include(en: "Province")
+    else
+      expect(option_set.level_names).to be_nil
+    end
     expect(option_set.total_options).to eq(26)
     expect(option_set.all_options).to include(have_attributes(canonical_name: "Kinshasa"))
   end


### PR DESCRIPTION
> Looks like this is happening when a single level option set has an option level name defined, which is not a typical scenario (would involve checking the 'multilevel' box filling in the name, then unchecking it). And this shouldn't really even be possible. issue to correct this: "Clear option level names for single-level option sets on save"

Diagnostics:
- The checkbox has been disabled for years, so I'm not sure how this would have happened in the first place: [blame for option_set_form.js](https://github.com/thecartercenter/nemo/blame/cc3b8ec979f7301b4f3e11bd14c3e1ea40b28815/app/assets/javascripts/legacy/views/option_set_form.js#L95)
- Ah, it must be from OptionSet imports! The header was used for `level_names` even if it was single-level
