### PR TITLE
10596 automated re-caching when things change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,13 +14,9 @@ gem "eventmachine", "~> 1.2", platform: :ruby
 gem "exception_notification", "~> 4.2"
 gem "fog-aws", "~> 3.3.0"
 gem "friendly_id", "~> 5.1.0"
-gem "hairtrigger", "~> 0.2.20"
 gem "immigrant", "~> 0.3.1" # foreign key maintenance
 gem "paperclip", "~> 6.0"
-gem "pg", "~> 0.20"
-gem "pg_search", "~> 2.1"
 gem "phony", "~> 2.15"
-gem "postgres-copy", "~> 1.0"
 gem "rack-attack", git: "https://github.com/sassafrastech/rack-attack.git"
 gem "rake", "~> 12.3.3"
 gem "random_data", "~> 1.6.0" # Deprecated: Use Faker instead
@@ -31,7 +27,6 @@ gem "rubyzip", "~> 1.3"
 gem "term-ansicolor", "~> 1.3.0"
 gem "thor", "0.19.1" # Newer versions produce command line argument errors. Remove constraint when fixed.
 gem "twilio-ruby", "~> 4.1.0"
-gem "whenever", "~> 0.9.4", require: false
 
 # JS/CSS
 gem "bootstrap", "~> 4.3.1"
@@ -88,9 +83,18 @@ gem "closure_tree", git: "https://github.com/sassafrastech/closure_tree.git"
 # Auto rank maintenance for sorted lists.
 gem "acts_as_list"
 
-# Performance
+# DB
+gem "hairtrigger", "~> 0.2.20"
+gem "pg", "~> 0.20"
+gem "pg_search", "~> 2.1"
+gem "postgres-copy", "~> 1.0"
+gem "wisper", "~> 2.0"
+gem "wisper-activerecord", "~> 1.0"
+
+# Background/async
 gem "delayed_job_active_record", "~> 4.1.3"
 gem "parallel", "~> 1.19"
+gem "whenever", "~> 0.9.4", require: false
 
 # I18n
 gem "i18n-country-translations", "~> 1.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,10 @@ GEM
     will_paginate (3.1.8)
     will_paginate-bootstrap4 (0.2.2)
       will_paginate (~> 3.0, >= 3.0.0)
+    wisper (2.0.1)
+    wisper-activerecord (1.0.0)
+      activerecord (>= 3.0.0)
+      wisper (~> 2.0)
     with_advisory_lock (4.0.0)
       activerecord (>= 4.2)
     xpath (3.2.0)
@@ -693,6 +697,8 @@ DEPENDENCIES
   whenever (~> 0.9.4)
   will_paginate (~> 3.1.7)
   will_paginate-bootstrap4 (~> 0.2.2)
+  wisper (~> 2.0)
+  wisper-activerecord (~> 1.0)
 
 BUNDLED WITH
    2.1.4

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -207,7 +207,7 @@ class Answer < ResponseNode
 
     # Manually mark as dirty since the creation of media objects
     # is difficult to listen for otherwise.
-    response.update!(dirty_json: true)
+    response&.update!(dirty_json: true)
   end
 
   def has_media_object?

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -49,6 +49,7 @@
 class Answer < ResponseNode
   include ActionView::Helpers::NumberHelper
   include PgSearch
+  include Wisper.model
 
   LOCATION_ATTRIBS = %i[latitude longitude altitude accuracy].freeze
   LOCATION_COLS = LOCATION_ATTRIBS.map(&:to_s).freeze

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -204,6 +204,10 @@ class Answer < ResponseNode
     elsif media_object_id != id
       self.media_object = Media::Object.find_by(id: id, answer_id: nil)
     end
+
+    # Manually mark as dirty since the creation of media objects
+    # is difficult to listen for otherwise.
+    response.update!(dirty_json: true)
   end
 
   def has_media_object?

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -42,6 +42,7 @@ class Form < ApplicationRecord
   include Replication::Replicable
   include Replication::Standardizable
   include MissionBased
+  include Wisper.model
 
   def self.receivable_association
     {name: :form_forwardings, fk: :recipient}

--- a/app/models/o_data/cache_listener.rb
+++ b/app/models/o_data/cache_listener.rb
@@ -21,6 +21,17 @@ module OData
       Response.where(user_id: user.id).update_all(dirty_json: true)
     end
 
+    def update_question_successful(question)
+      return unless attribs_changed?(question, %w[code])
+      form_ids = question.forms.pluck(:id)
+      Response.where(form_id: form_ids).update_all(dirty_json: true)
+    end
+
+    def update_qing_group_successful(qing_group)
+      return unless attribs_changed?(qing_group, %w[repeatable group_name_translations])
+      Response.where(form_id: qing_group.form.id).update_all(dirty_json: true)
+    end
+
     private
 
     def attribs_changed?(object, attribs)

--- a/app/models/o_data/cache_listener.rb
+++ b/app/models/o_data/cache_listener.rb
@@ -12,7 +12,7 @@ module OData
     end
 
     def update_answer_successful(answer)
-      return unless attribs_changed?(answer, %w[value date_value time_value datetime_value pending_file_name
+      return unless attribs_changed?(answer, %w[value date_value time_value datetime_value
                                                 option_node_id accuracy altitude latitude longitude])
       answer.response.update!(dirty_json: true)
     end

--- a/app/models/o_data/cache_listener.rb
+++ b/app/models/o_data/cache_listener.rb
@@ -33,8 +33,13 @@ module OData
       Response.where(form_id: form_ids).update_all(dirty_json: true)
     end
 
+    def update_questioning_successful(questioning)
+      return unless attribs_changed?(questioning, %w[rank])
+      Response.where(form_id: questioning.form_id).update_all(dirty_json: true)
+    end
+
     def update_qing_group_successful(qing_group)
-      return unless attribs_changed?(qing_group, %w[repeatable group_name_translations])
+      return unless attribs_changed?(qing_group, %w[rank repeatable group_name_translations])
       Response.where(form_id: qing_group.form.id).update_all(dirty_json: true)
     end
 

--- a/app/models/o_data/cache_listener.rb
+++ b/app/models/o_data/cache_listener.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module OData
+  # Marks the OData cached_json as dirty when things change.
+  class CacheListener
+    include Singleton
+
+    def update_response_successful(response)
+      # TODO: Eventually update the metadata ONLY.
+      return unless attribs_changed?(response, %w[shortcode form_id user_id reviewed])
+      response.update!(dirty_json: true)
+    end
+
+    def update_form_successful(form)
+      return unless attribs_changed?(form, %w[name])
+      Response.where(form_id: form.id).update_all(dirty_json: true)
+    end
+
+    def update_user_successful(user)
+      return unless attribs_changed?(user, %w[name])
+      Response.where(user_id: user.id).update_all(dirty_json: true)
+    end
+
+    private
+
+    def attribs_changed?(object, attribs)
+      (attribs & object.saved_changes.keys).any?
+    end
+  end
+end
+
+# Example JSON:
+# {
+#   "ResponseID": "ddf85bb0-2d3b-4643-b967-b13dd8635d3a",
+#   "ResponseShortcode": "jz-gts-u0w5d",
+#   "FormName": "My form",
+#   "ResponseSubmitterName": "User 1",
+#   "ResponseSubmitDate": "2020-01-01T23:41:10Z",
+#   "ResponseReviewed": false,
+#   "TextQ1": "foo",
+#   "group1": {
+#     "TextQ2": null,
+#     "SelectOneQ3": "Cat"
+#   }
+# }

--- a/app/models/o_data/cache_listener.rb
+++ b/app/models/o_data/cache_listener.rb
@@ -34,6 +34,9 @@ module OData
     end
 
     def update_questioning_successful(questioning)
+      # Note: Simple rank changes are a "false positive"; could be
+      # more performant if we listen specifically for *parent* changes
+      # instead (though Wisper may not easily handle this attrib).
       return unless attribs_changed?(questioning, %w[rank])
       Response.where(form_id: questioning.form_id).update_all(dirty_json: true)
     end

--- a/app/models/o_data/cache_listener.rb
+++ b/app/models/o_data/cache_listener.rb
@@ -11,6 +11,12 @@ module OData
       response.update!(dirty_json: true)
     end
 
+    def update_answer_successful(answer)
+      return unless attribs_changed?(answer, %w[value date_value time_value datetime_value pending_file_name
+                                                option_node_id accuracy altitude latitude longitude])
+      answer.response.update!(dirty_json: true)
+    end
+
     def update_form_successful(form)
       return unless attribs_changed?(form, %w[name])
       Response.where(form_id: form.id).update_all(dirty_json: true)

--- a/app/models/qing_group.rb
+++ b/app/models/qing_group.rb
@@ -50,6 +50,7 @@
 # A group of questions on a form.
 class QingGroup < FormItem
   include Translatable
+  include Wisper.model
 
   translates :group_name, :group_hint, :group_item_name
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -54,6 +54,7 @@ class Question < ApplicationRecord
   include Replication::Standardizable
   include MissionBased
   include Odk::Mediable
+  include Wisper.model
 
   # Note that the maximum allowable length is 22 chars (1 letter plus 21 letters/numbers)
   # The user is told that the max is 20.

--- a/app/models/questioning.rb
+++ b/app/models/questioning.rb
@@ -49,6 +49,8 @@
 
 # Models the appearance of a question on a form.
 class Questioning < FormItem
+  include Wisper.model
+
   alias answers response_nodes
 
   delegate :all_options, :media_prompt?, :auto_increment?, :code, :code=, :first_leaf_option_node,

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -59,6 +59,7 @@ class Response < ApplicationRecord
   extend FriendlyId
   include MissionBased
   include Cacheable
+  include Wisper.model
 
   LOCK_OUT_TIME = 10.minutes
   CODE_CHARS = ("a".."z").to_a + ("0".."9").to_a

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -104,6 +104,7 @@ class Response < ApplicationRecord
   scope :created_before, ->(date) { where("responses.created_at <= ?", date) }
   scope :latest_first, -> { order(created_at: :desc) }
   scope :dirty, -> { where(dirty_json: true) }
+  scope :live, -> { joins(:form).merge(Form.live) }
 
   # loads basic belongs_to associations
   scope :with_basic_assoc, -> { includes(:form, :user) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,7 @@
 
 class User < ApplicationRecord
   include Cacheable
+  include Wisper.model
 
   ROLES = %w[enumerator reviewer staffer coordinator].freeze
   SESSION_TIMEOUT = (Rails.env.development? ? 2.weeks : 60.minutes)

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -2,6 +2,7 @@
 
 Rails.application.config.after_initialize do
   Response.subscribe(OData::CacheListener.instance)
+  Answer.subscribe(OData::CacheListener.instance)
   Form.subscribe(OData::CacheListener.instance)
   User.subscribe(OData::CacheListener.instance)
   Question.subscribe(OData::CacheListener.instance)

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  Response.subscribe(OData::CacheListener.instance)
+  Form.subscribe(OData::CacheListener.instance)
+  User.subscribe(OData::CacheListener.instance)
+end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -4,4 +4,6 @@ Rails.application.config.after_initialize do
   Response.subscribe(OData::CacheListener.instance)
   Form.subscribe(OData::CacheListener.instance)
   User.subscribe(OData::CacheListener.instance)
+  Question.subscribe(OData::CacheListener.instance)
+  QingGroup.subscribe(OData::CacheListener.instance)
 end

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.config.after_initialize do
+  # Note: Only concrete (not abstract) classes can use Wisper.
   Response.subscribe(OData::CacheListener.instance)
   Answer.subscribe(OData::CacheListener.instance)
   Form.subscribe(OData::CacheListener.instance)

--- a/config/initializers/listeners.rb
+++ b/config/initializers/listeners.rb
@@ -7,5 +7,6 @@ Rails.application.config.after_initialize do
   Form.subscribe(OData::CacheListener.instance)
   User.subscribe(OData::CacheListener.instance)
   Question.subscribe(OData::CacheListener.instance)
+  Questioning.subscribe(OData::CacheListener.instance)
   QingGroup.subscribe(OData::CacheListener.instance)
 end

--- a/spec/jobs/cache_o_data_job_spec.rb
+++ b/spec/jobs/cache_o_data_job_spec.rb
@@ -42,6 +42,15 @@ describe CacheODataJob do
       described_class.perform_now
       expect(Response.all.pluck(:dirty_json)).to eq([false] * num_responses)
     end
+
+    it "ignores non-live responses" do
+      responses[0].form.update_status("draft")
+      responses[1].form.update_status("paused")
+      responses[2].form.update_status("live")
+
+      described_class.perform_now
+      expect(Response.all.pluck(:dirty_json)).to eq([true, true, false])
+    end
   end
 
   context "operation notes" do

--- a/spec/models/odata/cache_listener_spec.rb
+++ b/spec/models/odata/cache_listener_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe OData::CacheListener do
+  # Since we're testing changes to these objects immediately after creation,
+  # reload to avoid tricky issues related to memory or caching.
+  # An alternative solution is: `create(:form).tap { |f| Form.find(f.id) }`
+  let!(:user) { create(:user).reload }
+  let!(:form) { create(:form, question_types: %w[text select_one]).reload }
+  let!(:form2) { create(:form, question_types: ["text", %w[text text]]).reload }
+  let!(:response) do
+    create(:response, answer_values: %w[foo Cat], dirty_json: false, form: form, user: user).reload
+  end
+  let!(:response2) do
+    create(:response, answer_values: %w[bar Dog], dirty_json: false, form: form, user: user).reload
+  end
+  let!(:response3) do
+    create(:response, answer_values: ["foo", %w[bar baz]], dirty_json: false, form: form2).reload
+  end
+
+  describe "update response" do
+    it "marks dirty" do
+      response.update!(reviewed: true)
+      expect_dirty(response)
+    end
+
+    it "ignores irrelevant changes" do
+      response.update!(source: "foo")
+      expect_clean(response)
+    end
+  end
+
+  describe "update answer" do
+    it "marks dirty (value)" do
+      response.c[0].update!(value: "bar")
+      expect_dirty(response)
+    end
+
+    it "marks dirty (latitude)" do
+      response.c[0].update!(latitude: 1.0)
+      expect_dirty(response)
+    end
+  end
+
+  describe "update form" do
+    it "marks multiple dirty" do
+      response.form.update!(name: "foo")
+      expect_dirty(response)
+      expect_dirty(response2)
+      expect_clean(response3)
+    end
+  end
+
+  describe "update user" do
+    it "marks multiple dirty" do
+      response.user.update!(name: "foo")
+      expect_dirty(response)
+      expect_dirty(response2)
+      expect_clean(response3)
+    end
+  end
+
+  describe "update question" do
+    it "marks multiple dirty" do
+      response.c[0].question.update!(code: "foo")
+      expect_dirty(response)
+      expect_dirty(response2)
+      expect_clean(response3)
+    end
+  end
+
+  describe "update questioning" do
+    it "marks dirty" do
+      response.c[0].questioning.update!(rank: 5)
+      expect_dirty(response)
+    end
+  end
+
+  describe "update qing_group" do
+    it "marks dirty (rank)" do
+      response3.c[1].qing_group.update!(rank: 5)
+      expect_clean(response)
+      expect_clean(response2)
+      expect_dirty(response3)
+    end
+
+    it "marks dirty (repeatable)" do
+      response3.c[1].qing_group.update!(repeatable: true)
+      expect_clean(response)
+      expect_clean(response2)
+      expect_dirty(response3)
+    end
+
+    it "marks dirty (group_name_translations)" do
+      response3.c[1].qing_group.update!(group_name_en: "foo")
+      expect_clean(response)
+      expect_clean(response2)
+      expect_dirty(response3)
+    end
+  end
+
+  def expect_dirty(response)
+    expect(response.reload.dirty_json).to be_truthy
+  end
+
+  def expect_clean(response)
+    expect(response.reload.dirty_json).to be_falsey
+  end
+end

--- a/spec/models/odata/cache_listener_spec.rb
+++ b/spec/models/odata/cache_listener_spec.rb
@@ -3,108 +3,95 @@
 require "rails_helper"
 
 describe OData::CacheListener do
-  # Since we're testing changes to these objects immediately after creation,
-  # reload to avoid tricky issues related to memory or caching.
-  # An alternative solution is: `create(:form).tap { |f| Form.find(f.id) }`
+  # Note: Since we're testing changes to these objects immediately after creation,
+  # reload immediately to avoid tricky issues related to memory or caching.
+  # Alternative solution that doesn't require `let!`: `create(:form).tap { |f| Form.find(f.id) }`
   let!(:user) { create(:user).reload }
   let!(:form) { create(:form, question_types: %w[text select_one]).reload }
   let!(:form2) { create(:form, question_types: ["text", %w[text text]]).reload }
-  let!(:response) do
-    create(:response, answer_values: %w[foo Cat], dirty_json: false, form: form, user: user).reload
+  let!(:responses) do
+    [
+      create(:response, answer_values: %w[foo Cat], dirty_json: false, form: form, user: user).reload,
+      create(:response, answer_values: %w[bar Dog], dirty_json: false, form: form, user: user).reload,
+      create(:response, answer_values: ["foo", %w[bar baz]], dirty_json: false, form: form2).reload
+    ]
   end
-  let!(:response2) do
-    create(:response, answer_values: %w[bar Dog], dirty_json: false, form: form, user: user).reload
-  end
-  let!(:response3) do
-    create(:response, answer_values: ["foo", %w[bar baz]], dirty_json: false, form: form2).reload
-  end
+  let(:r1) { responses[0] }
+  let(:r2) { responses[1] }
+  let(:r3) { responses[2] }
 
   describe "update response" do
     it "marks dirty" do
-      response.update!(reviewed: true)
-      expect_dirty(response)
+      r1.update!(reviewed: true)
+      expect_responses_dirty(true, false, false)
     end
 
     it "ignores irrelevant changes" do
-      response.update!(source: "foo")
-      expect_clean(response)
+      r1.update!(source: "foo")
+      expect_responses_dirty(false, false, false)
     end
   end
 
   describe "update answer" do
     it "marks dirty (value)" do
-      response.c[0].update!(value: "bar")
-      expect_dirty(response)
+      r1.c[0].update!(value: "bar")
+      expect_responses_dirty(true, false, false)
     end
 
     it "marks dirty (latitude)" do
-      response.c[0].update!(latitude: 1.0)
-      expect_dirty(response)
+      r1.c[0].update!(latitude: 1.0)
+      expect_responses_dirty(true, false, false)
     end
   end
 
   describe "update form" do
     it "marks multiple dirty" do
-      response.form.update!(name: "foo")
-      expect_dirty(response)
-      expect_dirty(response2)
-      expect_clean(response3)
+      r1.form.update!(name: "foo")
+      expect_responses_dirty(true, true, false)
     end
   end
 
   describe "update user" do
     it "marks multiple dirty" do
-      response.user.update!(name: "foo")
-      expect_dirty(response)
-      expect_dirty(response2)
-      expect_clean(response3)
+      r1.user.update!(name: "foo")
+      expect_responses_dirty(true, true, false)
     end
   end
 
   describe "update question" do
     it "marks multiple dirty" do
-      response.c[0].question.update!(code: "foo")
-      expect_dirty(response)
-      expect_dirty(response2)
-      expect_clean(response3)
+      r1.c[0].question.update!(code: "foo")
+      expect_responses_dirty(true, true, false)
     end
   end
 
   describe "update questioning" do
-    it "marks dirty" do
-      response.c[0].questioning.update!(rank: 5)
-      expect_dirty(response)
+    it "marks multiple dirty" do
+      r1.c[0].questioning.update!(rank: 5)
+      expect_responses_dirty(true, true, false)
     end
   end
 
   describe "update qing_group" do
     it "marks dirty (rank)" do
-      response3.c[1].qing_group.update!(rank: 5)
-      expect_clean(response)
-      expect_clean(response2)
-      expect_dirty(response3)
+      r3.c[1].qing_group.update!(rank: 5)
+      expect_responses_dirty(false, false, true)
     end
 
     it "marks dirty (repeatable)" do
-      response3.c[1].qing_group.update!(repeatable: true)
-      expect_clean(response)
-      expect_clean(response2)
-      expect_dirty(response3)
+      r3.c[1].qing_group.update!(repeatable: true)
+      expect_responses_dirty(false, false, true)
     end
 
     it "marks dirty (group_name_translations)" do
-      response3.c[1].qing_group.update!(group_name_en: "foo")
-      expect_clean(response)
-      expect_clean(response2)
-      expect_dirty(response3)
+      r3.c[1].qing_group.update!(group_name_en: "foo")
+      expect_responses_dirty(false, false, true)
     end
   end
 
-  def expect_dirty(response)
-    expect(response.reload.dirty_json).to be_truthy
-  end
-
-  def expect_clean(response)
-    expect(response.reload.dirty_json).to be_falsey
+  # Reload all responses and expect certain ones to be dirty.
+  def expect_responses_dirty(*values)
+    responses.each(&:reload)
+    expect(responses.pluck(:dirty_json)).to eq(values)
   end
 end


### PR DESCRIPTION
Changed:
- Added Wisper to listen for changes that would require updating the OData cached_json
- Ignore non-live responses when caching batches for performance

Future work:
- Ability to isolate metadata updates (instead of full response caching) for performance (includes benchmarking JSONB updates etc.)
