### PR TITLE
11083 De-prioritize background jobs to let web stay fast

### DIFF
--- a/app/jobs/cache_o_data_job.rb
+++ b/app/jobs/cache_o_data_job.rb
@@ -3,14 +3,16 @@
 # Caches OData that may have changed.
 class CacheODataJob < ApplicationJob
   # Batches should be sufficiently small to not interfere with user-initiated jobs like Reports.
-  # In practice, 100 responses take ~10-30 seconds to cache on a small VM.
-  BATCH_SIZE = 300
+  # In practice, 100 responses take ~30-200 seconds to cache on a normal VM like `B2s`.
+  # It takes just a few milliseconds to transition between each batch.
+  BATCH_SIZE = 30
 
   # A user-facing Operation should be created if there are so many responses to cache
   # that it's worth tracking progress.
-  OPERATION_THRESHOLD = 1000
+  OPERATION_THRESHOLD = 300
 
   # Frequency at which the Operation.notes should be updated for the user.
+  # Has no effect if it's greater than BATCH_SIZE (notes are always updated on new batch).
   NOTES_INTERVAL = 100
 
   # Default to lower-priority queue.

--- a/docs/delayed-job.service
+++ b/docs/delayed-job.service
@@ -14,5 +14,9 @@ ExecStart=/home/deploy/elmo/bin/delayed_job start -n 1
 ExecStop=/home/deploy/elmo/bin/delayed_job stop
 TimeoutSec=120
 
+# Use all resources available, but step back when more important things are running.
+CPUWeight=20
+IOWeight=20
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
My goodness, it's a whole new world! Health is caching thousands of responses right now but the web server still runs like nothing is going on. Seriously a huge deal.

- Weights are out of 100 max
- More info: https://unix.stackexchange.com/a/495013/150560
- Docs: https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html

I can roll out this config change to the whole fleet via elmo-deploy if it looks good to you.

---

Hmm, though it worked for performance, it did NOT solve the underlying problem that led to health completely locking up (it happened again several minutes later). Still looking into why.