### PR TITLE
11052 report caching

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,11 +15,15 @@ ELMO::Application.configure do
   config.consider_all_requests_local = true
 
   # Caching may need to be turned on when testing caching itself.
-  # To do so, run `rails dev:cache` which will create this tempfile.
+  # To do so, you can run `rails dev:cache` which will create this tempfile.
+  # If you want to override this long-term, please do it privately in `local_config.rb`.
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
-    # See the dev setup guide for info on configuring memcached locally.
-    config.cache_store = :dalli_store, nil, {value_max_bytes: 2.megabytes}
+    config.cache_store = :dalli_store, nil, {namespace: "v1",
+                                             compress: true,
+                                             # See the dev setup guide for info on configuring memcached.
+                                             value_max_bytes: 2.megabytes,
+                                             error_when_over_max_size: true}
   else
     config.action_controller.perform_caching = false
     config.cache_store = :null_store

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,13 +14,16 @@ ELMO::Application.configure do
   # Show full error reports
   config.consider_all_requests_local = true
 
-  # Caching may need to be turned on when testing caching itself. If so, please use
-  # config/initializers/local_config.rb to override this value,
-  # or change it here but please don't commit the change!
-  config.action_controller.perform_caching = false
-
-  # This is here only in case the above value is overridden as described.
-  config.cache_store = :dalli_store, nil, {value_max_bytes: 2.megabytes}
+  # Caching may need to be turned on when testing caching itself.
+  # To do so, run `rails dev:cache` which will create this tempfile.
+  if Rails.root.join("tmp/caching-dev.txt").exist?
+    config.action_controller.perform_caching = true
+    # See the dev setup guide for info on configuring memcached locally.
+    config.cache_store = :dalli_store, nil, {value_max_bytes: 2.megabytes}
+  else
+    config.action_controller.perform_caching = false
+    config.cache_store = :null_store
+  end
 
   # care if the mailer can't send
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,8 @@ ELMO::Application.configure do
              rescue StandardError
                ""
              end
-  config.cache_store = :dalli_store, memcached_server, {namespace: "elmo#{revision}"}
+  config.cache_store = :dalli_store, memcached_server, {namespace: "elmo#{revision}",
+                                                        compress: true}
 
   # Disable Rails's static asset server
   # In production, Apache or nginx will already do this

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -26,6 +26,7 @@ Note to install the software below we recommend the following package managers:
 1. Memcached 1.4+
     - For development environments, caching is only needed if you are developing a feature that uses caching and want to test it.
     - In this case, be sure to increase the default slab page size to 2 MB. This is done by passing `-I 2m` to the `memcached` command.
+    - When using Homebrew via `brew install memcached; brew services start memcached`, slab size can be configured at `/usr/local/Cellar/memcached/1.x.x/homebrew.mxcl.memcached.plist`
 1. PostgreSQL 10+
     - Create empty databases for use by the app: `createdb elmo_development && createdb elmo_test`
 1. ImageMagick 6.7+


### PR DESCRIPTION
Large reports were not being cached because they exceeded the memcached limit. Enabling compression makes them ~5-10x smaller in practice, with a minor CPU overhead that seems worthwhile.

Even with compression, many reports will still exceed the default 1 MB memcached limit. We should probably increase that in production via `/etc/memcached.conf`

Proposal:
- `-m 128` (2x the default total memory limit, in MB)
- `-I 16m` (16x the default per-item memory limit -- may as well? We cache relatively few things that are shared by many users, and relatively few reports are actually this big)

Some reports (like LEON "MOY Analysis") uncompressed are **137.4 MB**!! Compressed is 10.1 MB, and data over the wire to the client is 3.6 MB. There's nothing I can think of to speed up ridiculous reports aside from heavy limiting and pushing people toward CSV exports.