### PR TITLE
11166 fix OData default value for Collections

### DIFF
--- a/app/models/results/response_json_generator.rb
+++ b/app/models/results/response_json_generator.rb
@@ -83,7 +83,8 @@ module Results
         if child_item.is_a?(QingGroup)
           add_nil_group_answers(child_item, json)
         else
-          json[node_key(child_item)] ||= nil
+          is_collection = OData::QuestionType.odata_type_for(child_item.question.qtype_name).is_a?(Array)
+          json[node_key(child_item)] ||= is_collection ? [] : nil
         end
       end
     end

--- a/spec/fixtures/response_json/legacy_new_qings.json
+++ b/spec/fixtures/response_json/legacy_new_qings.json
@@ -1,0 +1,13 @@
+{
+  "ResponseID": "*id1*",
+  "ResponseShortcode": "*shortcode1*",
+  "FormName": "Sample Form 1",
+  "ResponseSubmitterName": "A User 1",
+  "ResponseSubmitDate": "2020-04-20T06:30:00-06:00",
+  "ResponseReviewed": true,
+  "TextQ1": "foo",
+  "SelectMultipleQ3": [
+
+  ],
+  "TextQ2": null
+}

--- a/spec/models/results/response_json_generator_spec.rb
+++ b/spec/models/results/response_json_generator_spec.rb
@@ -87,6 +87,22 @@ describe Results::ResponseJsonGenerator, :reset_factory_sequences do
     end
   end
 
+  context "response with missing values" do
+    let(:form) do
+      create(:form, question_types: ["text"])
+    end
+    let!(:response) do
+      create(:response, form: form, reviewed: true, answer_values: ["foo"])
+    end
+
+    it "produces correct json with defaults" do
+      create(:questioning, form: form, question: create(:question, qtype_name: "text"))
+      create(:questioning, form: form, question:
+        create(:question, qtype_name: "select_multiple", option_names: %w[one two]))
+      is_expected.to match_json(prepare_response_json_expectation("legacy_new_qings.json"))
+    end
+  end
+
   context "legacy response - repeat group that no longer repeats" do
     let(:form) do
       create(:form,


### PR DESCRIPTION
It was hard to find conclusive docs; I finally found some context in https://issues.oasis-open.org/browse/ODATA-1071. OData explicitly disallows Collections from being null, requiring that they be empty arrays instead. For Collections, the Nullable attribute applies to its children instead of the property itself.

Hotfixing and re-caching on Secure2 immediately so Zied can use it.