### PR TITLE
5531: Make login more explicit in password reset

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -45,10 +45,13 @@ class PasswordResetsController < ApplicationController
     @user.password = params[:user][:password]
     @user.password_confirmation = params[:user][:password_confirmation]
 
-    if @user.save
+    # Don't log in automatically. This was causing an occasional bug in which
+    # the automatic login wasn't working.
+    if @user.save_without_session_maintenance
       User.ignore_blank_passwords = true
 
-      # If we get this far, the user has been logged in.
+      # Log in the user explicitly
+      UserSession.create!(login: @user.login, password: @user.password)
       post_login_housekeeping
 
       flash[:success] = t("password_reset.success")

--- a/spec/features/users/password_reset_spec.rb
+++ b/spec/features/users/password_reset_spec.rb
@@ -6,54 +6,99 @@ feature "password reset" do
   let(:user) { create(:user) }
 
   context "if not logged in" do
-    it "new password reset page should load" do
-      visit "/en/password-resets/new"
-      expect(page).to have_content("Enter your email")
-    end
+    describe "reset request" do
+      context "with user with email address" do
+        it "new password reset page should load" do
+          visit "/en/password-resets/new"
+          expect(page).to have_content("Enter your email")
+        end
 
-    it "submitting password reset form should reset perishable token and send email" do
-      old_tok = user.perishable_token
-      assert_difference("ActionMailer::Base.deliveries.size", +1) do
-        request_password_reset(user.email)
-        expect(page).to have_content("Success: Instructions to reset")
+        it "submitting password reset form should reset perishable token and send email" do
+          old_tok = user.perishable_token
+          assert_difference("ActionMailer::Base.deliveries.size", +1) do
+            request_password_reset(user.email)
+            expect(page).to have_content("Success: Instructions to reset")
+          end
+          expect(old_tok).not_to eq(user.reload.perishable_token)
+        end
+
+        it "should not automatically reset password" do
+          crypted_password = user.crypted_password
+          request_password_reset(user.email)
+          expect(user.reload.crypted_password).to eq(crypted_password)
+        end
+
+        it "should work when using login instead of email" do
+          assert_difference("ActionMailer::Base.deliveries.size", +1) do
+            request_password_reset(user.login)
+            expect(page).to have_content("Success: Instructions to reset")
+            expect(ActionMailer::Base.deliveries.last.to).to eq([user.email])
+          end
+        end
       end
-      expect(old_tok).not_to eq(user.reload.perishable_token)
-    end
 
-    it "should not automatically reset password" do
-      crypted_password = user.crypted_password
-      request_password_reset(user.email)
-      expect(user.reload.crypted_password).to eq(crypted_password)
-    end
+      context "with user with no email address" do
+        let(:user) { create(:user, :no_email) }
 
-    context "with user with email address" do
-      it "should work when using login instead of email" do
-        assert_difference("ActionMailer::Base.deliveries.size", +1) do
-          request_password_reset(user.login)
-          expect(page).to have_content("Success: Instructions to reset")
-          expect(ActionMailer::Base.deliveries.last.to).to eq([user.email])
+        it "should show error when using login instead of email" do
+          assert_difference("ActionMailer::Base.deliveries.size", 0) do
+            request_password_reset(user.login)
+            expect(page).to have_content("There is no email address associated with that account")
+          end
+        end
+      end
+
+      context "with ambiguous email address" do
+        let(:users) { create_list(:user, 2, email: "foo@bar.com") }
+
+        it "should show special error" do
+          assert_difference("ActionMailer::Base.deliveries.size", 0) do
+            request_password_reset(users.first.email)
+            expect(page).to have_content("There are multiple accounts associated with that email address")
+          end
         end
       end
     end
 
-    context "with user with no email address" do
-      let(:user) { create(:user, :no_email) }
+    describe "password update" do
+      before do
+        user.reset_perishable_token!
+      end
 
-      it "should show error when using login instead of email" do
-        assert_difference("ActionMailer::Base.deliveries.size", 0) do
-          request_password_reset(user.login)
-          expect(page).to have_content("There is no email address associated with that account")
+      context "with new password" do
+        it "should change password and log in user" do
+          visit("/en/password-resets/#{user.perishable_token}/edit")
+          expect(page).to have_content("please enter a new password for your account")
+          fill_in("Password", with: "newpasswordX123;")
+          fill_in("Retype Password", with: "newpasswordX123;")
+          click_on("Send")
+          expect(page).to be_logged_in
+          logout
+
+          real_login(user, "newpasswordX123;")
+          expect(page).to be_logged_in
         end
       end
-    end
 
-    context "with ambiguous email address" do
-      let(:users) { create_list(:user, 2, email: "foo@bar.com") }
+      context "with invalid password" do
+        it "should show validation message" do
+          visit("/en/password-resets/#{user.perishable_token}/edit")
+          fill_in("Password", with: "x")
+          fill_in("Retype Password", with: "x")
+          click_on("Send")
+          expect(page).to have_content("please enter a new password for your account")
+          expect(page).to have_content("Password must include at least")
+        end
+      end
 
-      it "should show special error" do
-        assert_difference("ActionMailer::Base.deliveries.size", 0) do
-          request_password_reset(users.first.email)
-          expect(page).to have_content("There are multiple accounts associated with that email address")
+      context "with existing password" do
+        it "should log in user" do
+          visit("/en/password-resets/#{user.perishable_token}/edit")
+          expect(page).to have_content("please enter a new password for your account")
+          fill_in("Password", with: test_password)
+          fill_in("Retype Password", with: test_password)
+          click_on("Send")
+          expect(page).to be_logged_in
         end
       end
     end

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -5,7 +5,7 @@ module FeatureSpecHelpers
     ENV["TEST_LOGGED_IN_USER_ID"] = user.id
   end
 
-  def real_login(user, password = "Password1")
+  def real_login(user, password = test_password)
     visit(login_path(locale: "en"))
     fill_in("Username", with: user.login)
     fill_in("Password", with: password)
@@ -117,6 +117,16 @@ module FeatureSpecHelpers
     # Should show, then hide the global loading indicator.
     wait_for_load_start
     wait_for_load_stop
+  end
+
+  def logout
+    find("#logout_button").click
+    expect(page).to have_content("Logged Out")
+  end
+
+  def be_logged_in
+    # Operations Panel only shows in header when logged in
+    have_content("Operations Panel")
   end
 
   def select2(value, options = {})


### PR DESCRIPTION
Added feature specs. Made login more explicit after successful passwd change.

Hopefully this fixes it!? 