### PR TITLE
Add .env.example and document in setup instructions

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,18 @@
+# Set to 'cloud' to use cloud storage with AWS.
+# Set to 'local' to store files locally.
+NEMO_PAPERCLIP_STORAGE_TYPE=local
+
+# These are only required when using cloud storage.
+NEMO_AWS_ACCESS_KEY_ID="XXXXXXXXXXXXXXXX"
+NEMO_AWS_SECRET_ACCESS_KEY="XXXXXXXXXXXXXXXX"
+NEMO_AWS_REGION="us-east-1"
+NEMO_AWS_BUCKET="your-bucket-name"
+
+# Max upload size in MiB (1 MiB = 2^20 bytes).
+# This should match the client_max_body_size setting in nginx.conf, which is the ultimate authority.
+NEMO_MAX_UPLOAD_SIZE_MIB=50
+
+# Set this to any value to enable OData compatibility mode with Azure Data Factory.
+# A missing feature in Data Factory prevents it from recognizing our resource URLs,
+# and it also doesn't support arrays or objects (like select_multiple, cascading select, or groups).
+NEMO_USE_DATA_FACTORY=

--- a/.env.development
+++ b/.env.development
@@ -16,3 +16,6 @@ NEMO_MAX_UPLOAD_SIZE_MIB=50
 # A missing feature in Data Factory prevents it from recognizing our resource URLs,
 # and it also doesn't support arrays or objects (like select_multiple, cascading select, or groups).
 NEMO_USE_DATA_FACTORY=
+
+# Set this to any value to force OData to be generated fresh each time (ignore the cache).
+NEMO_FORCE_FRESH_ODATA=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Set to true if you're using OData with Azure Data Factory.
+# A missing feature in Data Factory prevents it from recognizing our resource URLs.
+NEMO_USE_DATA_FACTORY=

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-# Set to true if you're using OData with Azure Data Factory.
-# A missing feature in Data Factory prevents it from recognizing our resource URLs.
-NEMO_USE_DATA_FACTORY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .bundle
 .DS_Store
-.env
+.env*
 db/*.sqlite3
 db/sphinx
 log

--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -45,7 +45,7 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
   def transform_json_for_entry(json)
     cached_json = json["CachedJson"]
     # Lazy-cache the JSON if it hasn't been cached yet.
-    if cached_json.blank? || Settings.force_fresh_odata.present?
+    if cached_json.blank? || ENV["NEMO_FORCE_FRESH_ODATA"].present?
       response = Response.find(json["Id"])
       cached_json = CacheODataJob.cache_response(response)
       # Normally this replacement happens in SQL when querying the data.

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -112,7 +112,7 @@ git checkout develop
 1. Install the required gems by running `bundle install` in the project directory.
 1. Install the required Node modules by running `yarn install` in the project directory.
 1. Run `cp config/database.yml.example config/database.yml`.
-1. Run `cp .env.example .env` and adjust settings as appropriate.
+1. (optional) Run `cp .env.development .env.development.local` and adjust settings as appropriate.
 1. Run `cp config/initializers/local_config.rb.example config/initializers/local_config.rb` and adjust settings as appropriate. Note that the reCAPTCHA and Google Maps API Key must be valid keys for those services in order for tests to pass.
 1. Setup the UUID postgres extension:
     1. On Linux: `sudo -u postgres psql nemo_development -c 'CREATE EXTENSION "uuid-ossp"'`

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -112,7 +112,7 @@ git checkout develop
 1. Install the required gems by running `bundle install` in the project directory.
 1. Install the required Node modules by running `yarn install` in the project directory.
 1. Run `cp config/database.yml.example config/database.yml`.
-1. Run `cp config/settings.local.yml.example config/settings.local.yml` and adjust settings as appropriate.
+1. Run `cp .env.example .env` and adjust settings as appropriate.
 1. Run `cp config/initializers/local_config.rb.example config/initializers/local_config.rb` and adjust settings as appropriate. Note that the reCAPTCHA and Google Maps API Key must be valid keys for those services in order for tests to pass.
 1. Setup the UUID postgres extension:
     1. On Linux: `sudo -u postgres psql nemo_development -c 'CREATE EXTENSION "uuid-ossp"'`

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -367,6 +367,10 @@ Upgrading should be done in stages. Start with the stage closest to your current
 1. [Sentry](https://sentry.io/for/rails/) error tracking is now enabled by default. This means NEMO will automatically send us diagnostic logs when Rails errors occur. These error reports help us fix bugs faster, but may unintentionally reveal information to us about your servers or users. Please disable Sentry in `config/application.rb` (or switch to your own personal URL) if you wish to opt out.
     1. You can still configure the server to email you when errors occur via `config/local_config.rb`; this will not disable Sentry.
 
+#### Upgrading to v11.11
+
+1. Move any relevant configs from `config/settings.local.yml` to `.env`
+
 #### Upgrading to latest
 
 1. Follow the 'General Upgrade Instructions' below.

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -369,7 +369,7 @@ Upgrading should be done in stages. Start with the stage closest to your current
 
 #### Upgrading to v11.11
 
-1. Move any relevant configs from `config/settings.local.yml` to `.env`
+1. Migrate any configs from `config/settings.local.yml` to `.env` (see `.env.development` for what the new keys should be named)
 
 #### Upgrading to latest
 


### PR DESCRIPTION
Now that settings.local.yml.example is gone, shouldn't we have .env.example for local development with all the old values defaulted there instead? (If I understand correctly, the `nemo-deploy` server will control `.env` on cloud servers so this change is only for local development)

Just trying to understand the migration path. Several things have changed and I don't quite remember what else is coming down the pipe.