### PR TITLE
11177: Fix standard report to mark self populated

### DIFF
--- a/app/models/report/standard_form_report.rb
+++ b/app/models/report/standard_form_report.rb
@@ -118,9 +118,6 @@ class Report::StandardFormReport < Report::Report
     h[:disagg_qing] = disagg_qing.as_json(only: :id, include: {question: {only: :code}})
     h[:no_data] = no_data?
     h[:raw_answer_limit] = Report::SummaryCollectionBuilder::RAW_ANSWER_LIMIT
-
-    self.populated = true
-
     h
   end
 
@@ -150,6 +147,8 @@ class Report::StandardFormReport < Report::Report
     @summary_collection.subsets.each do |s|
       s.build_tag_groups(question_order: question_order || "number", group_by_tag: group_by_tag)
     end
+
+    self.populated = true
 
     @summary_collection
   end


### PR DESCRIPTION
Apparently this has broken for at least an olympiad...

The standard report was not marking itself populated properly after running, so the view wasn't rendering itself. Only happened in cases where the report data is sent in the AJAX response rather than after a refresh, when it's run anew.