### PR TITLE
11300: Set explicit ordering on responses

### DIFF
--- a/app/overrides/o_data_controller_override.rb
+++ b/app/overrides/o_data_controller_override.rb
@@ -88,6 +88,7 @@ ODataController.class_eval do # rubocop:disable Metrics/BlockLength
     new = request.base_url
     response = Response
       .where(form_id: form.id)
+      .order(created_at: :desc)
       .select("*, replace(cached_json::text, '#{old}', '#{new}')::jsonb AS cached_json")
     entity = schema.add_entity_type(response, name: OData::FormDecorator.new(form).responses_name,
                                               url_name: OData::FormDecorator.new(form).responses_url,

--- a/spec/requests/odata/resource_spec.rb
+++ b/spec/requests/odata/resource_spec.rb
@@ -33,27 +33,27 @@ describe "OData resource" do
         "@odata.context": "http://www.example.com/en/m/#{mission.compact_name}" \
           "#{OData::BASE_PATH}/$metadata#Responses: #{form.name}",
         value: [
-          json_for(form, form.responses[0], "IntegerQ1": 3,
-                                            "SelectOneQ2": "Dog",
-                                            "TextQ3": "Baz"),
-          json_for(form, form.responses[1], "IntegerQ1": 2,
-                                            "SelectOneQ2": "Cat",
-                                            "TextQ3": "Bar"),
-          json_for(form, form.responses[2], "IntegerQ1": 1,
-                                            "SelectOneQ2": "Dog",
-                                            "TextQ3": "Foo")
+          json_for(form, responses[2], "IntegerQ1": 3,
+                                       "SelectOneQ2": "Dog",
+                                       "TextQ3": "Baz"),
+          json_for(form, responses[1], "IntegerQ1": 2,
+                                       "SelectOneQ2": "Cat",
+                                       "TextQ3": "Bar"),
+          json_for(form, responses[0], "IntegerQ1": 1,
+                                       "SelectOneQ2": "Dog",
+                                       "TextQ3": "Foo")
         ]
       )
     end
 
     context "navigating to an Entry" do
-      let(:path) { "#{mission_api_route}/Responses-#{form.id}(#{form.responses[0].id})" }
+      let(:path) { "#{mission_api_route}/Responses-#{form.id}(#{responses[0].id})" }
 
       it "renders as expected" do
         expect_json(
-          json_for(form, form.responses[0], "IntegerQ1": 3,
-                                            "SelectOneQ2": "Dog",
-                                            "TextQ3": "Baz")
+          json_for(form, responses[0], "IntegerQ1": 1,
+                                       "SelectOneQ2": "Dog",
+                                       "TextQ3": "Foo")
             .merge("@odata.context": "http://www.example.com/en/m/#{mission.compact_name}" \
               "#{OData::BASE_PATH}/$metadata#Responses: #{form.name}/$entity")
         )
@@ -71,7 +71,7 @@ describe "OData resource" do
         "@odata.context": "http://www.example.com/en/m/#{mission.compact_name}" \
           "#{OData::BASE_PATH}/$metadata#Responses: #{form.name}",
         value: [
-          json_for(form, form.responses[0], "SelectOneQ1": "Chat")
+          json_for(form, responses[0], "SelectOneQ1": "Chat")
         ]
       )
     end

--- a/spec/support/contexts/o_data.rb
+++ b/spec/support/contexts/o_data.rb
@@ -55,43 +55,49 @@ shared_context "odata with basic forms" do
   let(:other_form) do
     create(:form, :live, name: "Form 5", mission: other_mission, question_types: %w[text])
   end
-
-  before do
-    Timecop.freeze(Time.now.utc - 10.days) do
-      create(:response, mission: mission, form: form, answer_values: [1, "Dog", "Foo"])
-    end
-    Timecop.freeze(Time.now.utc - 5.days) do
-      create(:response, mission: mission, form: form, answer_values: [2, "Cat", "Bar"])
-    end
-    create(:response, mission: mission, form: form, answer_values: [3, "Dog", "Baz"])
-    create(:response, mission: mission, form: paused_form, answer_values: ["X"])
-    create(:response, mission: mission, form: draft_form, answer_values: ["X"])
-    create(:response, mission: other_mission, form: other_form, answer_values: ["X"])
+  let!(:responses) do
+    [
+      Timecop.freeze(Time.now.utc - 10.days) do
+        create(:response, mission: mission, form: form, answer_values: [1, "Dog", "Foo"])
+      end,
+      Timecop.freeze(Time.now.utc - 5.days) do
+        create(:response, mission: mission, form: form, answer_values: [2, "Cat", "Bar"])
+      end,
+      create(:response, mission: mission, form: form, answer_values: [3, "Dog", "Baz"]),
+      create(:response, mission: mission, form: paused_form, answer_values: ["X"]),
+      create(:response, mission: mission, form: draft_form, answer_values: ["X"]),
+      create(:response, mission: other_mission, form: other_form, answer_values: ["X"])
+    ]
   end
 end
 
 shared_context "odata with multilingual forms" do
   let(:form) { create(:form, :live, mission: mission, question_types: %w[select_one]) }
+  let!(:responses) do
+    [
+      # Submitted as "Cat" but should be rendered as "Chat".
+      create(:response, mission: mission, form: form, answer_values: ["Cat"])
+    ]
+  end
 
   before do
     mission.setting.update!(preferred_locales: %i[fr en])
     node = form.c[0].question.option_set.c[0]
     node.option.update!(name_fr: "Chat")
-
-    # Submitted as "Cat" but should be rendered as "Chat".
-    create(:response, mission: mission, form: form, answer_values: ["Cat"])
   end
 end
 
 shared_context "odata with nested groups" do
   let!(:form) { create(:form, :live, question_types: ["text", %w[text integer], ["text", %w[integer text]]]) }
-
-  before do
-    Timecop.freeze(Time.now.utc - 10.days) do
-      create(:response, mission: mission, form: form, answer_values: [%w[A B], ["C", 10], ["D", [21, "E1"]]])
-    end
-    Timecop.freeze(Time.now.utc - 5.days) do
-      create(:response, mission: mission, form: form, answer_values: [])
-    end
+  let!(:responses) do
+    [
+      Timecop.freeze(Time.now.utc - 10.days) do
+        create(:response, mission: mission, form: form,
+                          answer_values: [%w[A B], ["C", 10], ["D", [21, "E1"]]])
+      end,
+      Timecop.freeze(Time.now.utc - 5.days) do
+        create(:response, mission: mission, form: form, answer_values: [])
+      end
+    ]
   end
 end


### PR DESCRIPTION
This one came up again. 

There were actually two sources of indeterminate ordering:

1. The order of the responses in the ODataController
2. The order of the responses in the spec itself.

I set up explicit ordering for both. Hopefully this should fix it. @cooperka please note how I did this in the spec, by just storing the responses in a let var instead of saving and reloading them. If doing the latter, you'd need to use an `order` clause, but storing in a let is more efficient anyway.