### PR TITLE
11390 fix OData for Power BI

### DIFF
--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -11,8 +11,7 @@ module OData
       ResponseID: :id,
       ResponseShortcode: :string,
       ResponseReviewed: :boolean,
-      FormName: :string,
-      LastCached: :datetime
+      FormName: :string
     }.freeze
 
     GEOGRAPHIC_PROPERTIES = Answer::LOCATION_COLS.map do |key|

--- a/spec/fixtures/odata/basic_metadata.xml
+++ b/spec/fixtures/odata/basic_metadata.xml
@@ -20,7 +20,6 @@
         <Property Name="ResponseShortcode" Type="Edm.String" Nullable="true"/>
         <Property Name="ResponseReviewed" Type="Edm.Boolean" Nullable="true"/>
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
-        <Property Name="LastCached" Type="Edm.DateTimeOffset" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form1*" OpenType="true" BaseType="NEMO.Response">
         <Property Name="*q_code1*" Type="Edm.Int64" Nullable="true"/>

--- a/spec/fixtures/odata/empty_metadata.xml
+++ b/spec/fixtures/odata/empty_metadata.xml
@@ -20,7 +20,6 @@
         <Property Name="ResponseShortcode" Type="Edm.String" Nullable="true"/>
         <Property Name="ResponseReviewed" Type="Edm.Boolean" Nullable="true"/>
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
-        <Property Name="LastCached" Type="Edm.DateTimeOffset" Nullable="true"/>
       </EntityType>
       <EntityContainer Name="NEMOService">
         <EntitySet Name="Custom" EntityType="NEMO.Custom">

--- a/spec/fixtures/odata/nested_groups_metadata.xml
+++ b/spec/fixtures/odata/nested_groups_metadata.xml
@@ -32,7 +32,6 @@
         <Property Name="ResponseShortcode" Type="Edm.String" Nullable="true"/>
         <Property Name="ResponseReviewed" Type="Edm.Boolean" Nullable="true"/>
         <Property Name="FormName" Type="Edm.String" Nullable="true"/>
-        <Property Name="LastCached" Type="Edm.DateTimeOffset" Nullable="true"/>
       </EntityType>
       <EntityType Name="Responses: *form1*" OpenType="true" BaseType="NEMO.Response">
         <Property Name="*q_code1*" Type="Edm.String" Nullable="true"/>


### PR DESCRIPTION
I unintentionally included `LastCached` in metadata during a dev tooling improvement. Removing, otherwise it breaks Power BI if it's not provided in cached legacy data.

The data will still be sent down for debugging purposes, it just won't be listed in the "fields I promise to send you" metadata.