### PR TITLE
11418: Show better DropZone error message for unauthorized file uploads

### DIFF
--- a/app/assets/javascripts/views/file_uploader_view.js
+++ b/app/assets/javascripts/views/file_uploader_view.js
@@ -60,7 +60,9 @@ ELMO.Views.FileUploaderView = class FileUploaderView extends ELMO.Views.Applicat
     this.dropzone.removeFile(file);
     const errors = responseData.errors
       ? responseData.errors.join('<br/>')
-      : I18n.t('errors.file_upload.error');
+      : responseData === 'RECENT_LOGIN_REQUIRED'
+        ? I18n.t('errors.file_upload.login_error')
+        : I18n.t('errors.file_upload.error');
     return this.$('.dz-error-msg').show().html(errors);
   }
 

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -156,6 +156,7 @@ en:
     format: "%{attribute}: %{message}"
     file_upload:
       error: "There was an error uploading the file."
+      login_error: "You are no longer signed in, please refresh the page and try again."
       file_missing: "No file selected for import."
       invalid_format: "The uploaded file was not an accepted format."
       internal: "An internal error occurred while processing your upload."


### PR DESCRIPTION
Dropzone shows "There was an error uploading the file" when really you just got signed out due to inactivity and need to refresh the page. The user import dropzone in particular requires re-authorization so this happens in a fairly short time window.

Note: the `RECENT_LOGIN_REQUIRED` string is defined in `authorization.rb`