### PR TITLE
11425 fix odk formList caching

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -41,7 +41,9 @@ class FormsController < ApplicationController
       # OpenRosa format for ODK
       format.xml do
         authorize!(:download, Form)
-        @cache_key = "#{Form.odk_index_cache_key(mission: current_mission)}/#{CACHE_SUFFIX}"
+        # Also cache based on host because this endpoint returns full URLs for form access.
+        # Ignoring host leads to issues with proxies or when debugging across localhost/0.0.0.0/ngrok.
+        @cache_key = "#{Form.odk_index_cache_key(mission: current_mission)}/#{request.host}/#{CACHE_SUFFIX}"
         @forms = @forms.live
       end
     end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -3,7 +3,7 @@
 # FormController
 class FormsController < ApplicationController
   # Increment to expire caches for this controller as needed due to changes.
-  CACHE_SUFFIX = "/2"
+  CACHE_SUFFIX = "2"
 
   include StandardImportable
   include BatchProcessable
@@ -41,7 +41,7 @@ class FormsController < ApplicationController
       # OpenRosa format for ODK
       format.xml do
         authorize!(:download, Form)
-        @cache_key = "#{Form.odk_index_cache_key(mission: current_mission)}#{CACHE_SUFFIX}"
+        @cache_key = "#{Form.odk_index_cache_key(mission: current_mission)}/#{CACHE_SUFFIX}"
         @forms = @forms.live
       end
     end
@@ -96,7 +96,7 @@ class FormsController < ApplicationController
   # Format is always :xml
   def odk_manifest
     authorize!(:download, @form)
-    @cache_key = "#{@form.odk_download_cache_key}/manifest#{CACHE_SUFFIX}"
+    @cache_key = "#{@form.odk_download_cache_key}/manifest/#{CACHE_SUFFIX}"
     return if fragment_exist?(@cache_key)
 
     questions = @form.enabled_questionings.map(&:question).select(&:media_prompt?)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -109,13 +109,16 @@ class Form < ApplicationRecord
     FormVersion.where(form_id: form_ids).delete_all
   end
 
-  # Gets a cache key based on the mission and the max (latest) published_changed_at value.
+  # Gets a cache key based on the mission and various timestamps.
   def self.odk_index_cache_key(options)
     # Note that since we're using maximum method, dates don't seem to be TZ adjusted on load,
     # which is fine as long as it's consistent.
     max_published_changed_at =
       if for_mission(options[:mission]).live.any?
-        for_mission(options[:mission]).maximum(:published_changed_at).utc.to_s(:cache_datetime)
+        [
+          for_mission(options[:mission]).maximum(:published_changed_at),
+          for_mission(options[:mission]).live.maximum(:updated_at)
+        ].max.utc.to_s(:cache_datetime)
       else
         "no-pubd-forms"
       end

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -141,6 +141,15 @@ describe Form do
       end
     end
 
+    context "when updating a form name" do
+      it "should change" do
+        old = Form.odk_index_cache_key(mission: get_mission)
+        form2.update(name: "form2 changed")
+        new = Form.odk_index_cache_key(mission: get_mission)
+        expect(new).not_to eq(old)
+      end
+    end
+
     context "for mission with no forms" do
       let(:mission2) { create(:mission) }
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -134,19 +134,15 @@ describe Form do
 
     context "when updating a form version" do
       it "should change" do
-        old = Form.odk_index_cache_key(mission: get_mission)
-        form2.increment_version
-        new = Form.odk_index_cache_key(mission: get_mission)
-        expect(new).not_to eq(old)
+        expect { form2.increment_version }
+          .to(change { Form.odk_index_cache_key(mission: get_mission) })
       end
     end
 
     context "when updating a form name" do
       it "should change" do
-        old = Form.odk_index_cache_key(mission: get_mission)
-        form2.update(name: "form2 changed")
-        new = Form.odk_index_cache_key(mission: get_mission)
-        expect(new).not_to eq(old)
+        expect { form2.update!(name: "New Name!") }
+          .to(change { Form.odk_index_cache_key(mission: get_mission) })
       end
     end
 
@@ -378,6 +374,7 @@ describe Form do
     f = options[:form] || form
     f.update_status(:live)
     f.published_changed_at -= (options[:diff] || 1.hour)
+    f.updated_at -= (options[:diff] || 1.hour)
     f.save! if options[:save]
   end
 end


### PR DESCRIPTION
Fixes 2 issues related to ODK formList caching:
- List doesn't update when form name changes
- List doesn't update when you access it via proxy, so the URLs are invalid and it leads to really strange low-level Android bugs in the Collect app. Relevant when debugging locally but would also apply to any regular proxy in production.
