### PR TITLE
11473: Restore page title on print form and refactor

### DIFF
--- a/app/assets/stylesheets/local/forms/_printable.scss
+++ b/app/assets/stylesheets/local/forms/_printable.scss
@@ -8,7 +8,7 @@
     }
   }
 
-  #printable_form {
+  #printable-form {
     h1.title {
       display: block;
       margin-bottom: 3px;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,49 +135,35 @@ module ApplicationHelper
     pluralize_model(model, count: 1)
   end
 
-  # gets or constructs the page title from the translation file or from an explicitly set @title
-  # returns empty string if no translation found and no explicit title set
-  # looks for special :standard option in @title_args, shows seal if set
-  # options[:text_only] - don't return any images or html
-  def title(options = {})
-    # use explicit title if given
+  # Gets or constructs the page title from the translation file or from an explicitly set @title.
+  # returns nil if no translation found and no explicit title set
+  def title(text_only: false, name_only: false, standardized: false, name: nil, **i18n_params)
     return @title unless @title.nil?
 
-    @title_args ||= {}
-
-    # if action specified outright, use that
-    action = @title_action ||
-      case action_name
-      when "update" then "edit"
-      when "create" then "new"
-      else action_name
-      end
-
-    "".html_safe.tap do |ttl|
+    safe_str.tap do |result|
       model_name = controller_name.classify.downcase
 
       # Add standard icon if appropriate
-      ttl << std_icon(@title_args[:standardized]) unless options[:text_only]
+      result << std_icon(standardized) unless text_only
 
       # Add object type icon where appropriate
-      if !options[:text_only] && IconHelper::FONT_AWESOME_ICON_MAPPINGS.include?(model_name.to_sym)
-        ttl << icon_tag(model_name)
+      if !text_only && IconHelper::FONT_AWESOME_ICON_MAPPINGS.include?(model_name.to_sym)
+        result << icon_tag(model_name)
       end
 
-      # add text
-      ttl << if options[:name_only]
-               @title_args[:name]
-             else
-               options = {scope: "page_titles.#{controller_name}", default: [:all, ""]}
-                 .merge(@title_args || {})
-               t(action, **options)
-             end
+      result << if name_only
+                  name
+                else
+                  i18n_params[:name] = name
+                  params = {scope: "page_titles.#{controller_name}", default: [:all, ""]}.merge(i18n_params)
+                  t(action_name, **params)
+                end
     end
   end
 
-  def h1_title(content: "")
+  def h1_title(content: "", **args)
     content_tag(:h1, class: "title") do
-      title << content
+      title(**args) << content
     end
   end
 

--- a/app/views/forms/_printable.html.erb
+++ b/app/views/forms/_printable.html.erb
@@ -1,7 +1,9 @@
-<div id="printable_form" class="d-none d-print-block">
+<div id="printable-form" class="d-none d-print-block">
   <%= logo_image(style: :dark, class: "logo") %>
-  <h1 class="title"><%= title(name_only: true) %></h1>
-  <div class="mission"><%= current_mission.try(:name) || "[#{t('form.no_mission')}]" %></div>
+  <h1 class="title">
+    <%= title(name_only: true, name: @form.name, standardized: @form.standardized?) %>
+  </h1>
+  <div class="mission"><%= current_mission&.name || "[#{t('form.no_mission')}]" %></div>
   <table>
     <tr>
       <td class="name"><%= Response.human_attribute_name("user_id") %></td>

--- a/app/views/forms/choose_questions.html.erb
+++ b/app/views/forms/choose_questions.html.erb
@@ -1,4 +1,4 @@
-<% @title_args = {:name => @form.name} %>
+<% @title_args = {name: @form.name} %>
 
 <% unless questions.empty? %>
   <div class="question_list">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,8 @@
 <html dir="<%= current_direction %>">
 <head>
   <title>
-    <%= current_mission_config.site_name %><%= (ttl = title(:text_only => true)).blank? ? "" : ": #{ttl}" %>
+    <%= [current_mission_config.site_name,
+         title(text_only: true, **(@title_args || {}))].compact.join(": ") %>
   </title>
 
   <%= main_stylesheet_tag(params) %>
@@ -111,7 +112,7 @@
     <%= yield(:alerts) %>
     <% unless @dont_print_title %>
       <div id="title-container">
-        <%= h1_title(content: yield(:title_content)) %>
+        <%= h1_title(content: yield(:title_content), **(@title_args || {})) %>
       </div>
     <% end %>
     <%= body %>

--- a/app/views/missions/form.html.erb
+++ b/app/views/missions/form.html.erb
@@ -1,4 +1,4 @@
-<% @title_args = {:name => @mission.name} %>
+<% @title_args = {name: @mission.name} %>
 
 <%= elmo_form_for(@mission) do |f| %>
   <%= ActionLinks::LinkBuilder.new(@mission, %i[edit destroy]) %>

--- a/app/views/operations/show.html.erb
+++ b/app/views/operations/show.html.erb
@@ -1,4 +1,4 @@
-<% @title_args = { name: @operation.name } %>
+<% @title_args = {name: @operation.name} %>
 <%= elmo_form_for(@operation) do |f| %>
   <%= ActionLinks::LinkBuilder.new(@operation, %i[destroy]) %>
   <%= f.field :id %>

--- a/spec/features/forms/form/printable_spec.rb
+++ b/spec/features/forms/form/printable_spec.rb
@@ -20,7 +20,7 @@ feature "forms", js: true do
       it "should work and show tip" do
         visit(url)
         page.execute_script("localStorage.removeItem('form_print_format_tips_shown')")
-        using_wait_time longer_wait_time do
+        using_wait_time(longer_wait_time) do
           find("a.print-link").click
           expect(page).to have_css("h4", text: "Print Format Tips")
 
@@ -38,7 +38,7 @@ feature "forms", js: true do
         visit(url)
         date = Time.zone.today.strftime("%Y-%m-%d")
         page.execute_script("localStorage.setItem('form_print_format_tips_shown', '#{date}')")
-        using_wait_time longer_wait_time do
+        using_wait_time(longer_wait_time) do
           find("a.print-link").click
           wait_for_load
           expect(page).not_to have_css("h4", text: "Print Format Tips")
@@ -60,5 +60,23 @@ feature "forms", js: true do
   describe "print from form edit page" do
     let(:url) { "/en/m/#{form.mission.compact_name}/forms/#{form.id}/edit" }
     it_behaves_like "shows tips and prints"
+  end
+
+  context "when viewing print media" do
+    let(:url) { "/en/m/#{form.mission.compact_name}/forms" }
+
+    it "should have form title" do
+      visit(url)
+
+      using_wait_time(longer_wait_time) do
+        find("a.print-link").click
+        click_button("OK")
+        wait_for_load
+      end
+
+      with_print_emulation do
+        expect(page).to have_css("h1", text: "Foo")
+      end
+    end
   end
 end

--- a/spec/support/helpers/feature_spec_helpers.rb
+++ b/spec/support/helpers/feature_spec_helpers.rb
@@ -207,4 +207,12 @@ module FeatureSpecHelpers
       text;
     })
   end
+
+  def with_print_emulation
+    bridge = Capybara.current_session.driver.browser.send(:bridge)
+    path = "/session/#{bridge.session_id}/chromium/send_command"
+    bridge.http.call(:post, path, cmd: "Emulation.setEmulatedMedia", params: {media: "print"})
+    yield
+    bridge.http.call(:post, path, cmd: "Emulation.setEmulatedMedia", params: {media: ""})
+  end
 end


### PR DESCRIPTION
I still don't love the way page titles are handled but this cleans things up a bit.