### PR TITLE
11474 form page load time

### DIFF
--- a/app/helpers/option_sets_helper.rb
+++ b/app/helpers/option_sets_helper.rb
@@ -22,7 +22,6 @@ module OptionSetsHelper
       # only show the first 3 options as there could be many many
       option_set.options[0...3].collect(&:name).join(", ") + (option_set.options.size > 3 ? ", ..." : "")
     when "questions" then option_set.questions_count
-    when "answers" then number_with_delimiter(option_set.answer_count)
     when "actions"
       # add a clone link if auth'd
       if can?(:clone, option_set)

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -303,24 +303,6 @@ class Form < ApplicationRecord
     update_columns(downloads: 0, published_changed_at: Time.current)
   end
 
-  # efficiently gets the number of answers for the given questioning on this form
-  # returns zero if form is standard
-  def qing_answer_count(qing)
-    return 0 if standard?
-
-    @answer_counts ||= Questioning.find_by_sql([%{
-      SELECT form_items.id, COUNT(DISTINCT answers.id) AS answer_count
-      FROM form_items
-        LEFT OUTER JOIN answers ON answers.questioning_id = form_items.id
-          AND form_items.type = 'Questioning'
-      WHERE form_items.form_id = ?
-      GROUP BY form_items.id
-    }, id]).index_by(&:id)
-
-    # get the desired count
-    @answer_counts[qing.id].try(:answer_count) || 0
-  end
-
   private
 
   def init_downloads

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -209,10 +209,6 @@ class OptionSet < ApplicationRecord
     standard? ? copies.to_a.sum(&:question_count) : 0
   end
 
-  def answer_count
-    standard? ? copies.to_a.sum(&:answer_count) : questionings.to_a.sum(&:answer_count)
-  end
-
   # gets all forms to which this option set is linked (through questionings)
   def forms
     questionings.collect(&:form).uniq

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -177,11 +177,6 @@ class Question < ApplicationRecord
     location_type? || qtype_name == "select_one" && option_set.geographic?
   end
 
-  # DEPRECATED: this method should go away later
-  def select_options
-    (first_level_options || []).map { |o| [o.name, o.id] }
-  end
-
   # gets the number of forms which with this question is directly associated
   def form_count
     forms.count

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -187,12 +187,8 @@ class Question < ApplicationRecord
     forms.count
   end
 
-  def answer_count
-    standard? ? copies.to_a.sum(&:answer_count) : response_nodes.count
-  end
-
   def data?
-    answer_count.positive?
+    response_nodes.exists?
   end
 
   def in_use?

--- a/app/models/questioning.rb
+++ b/app/models/questioning.rb
@@ -76,15 +76,8 @@ class Questioning < FormItem
     form.not_draft?
   end
 
-  # checks if this form has any answers
-  # uses the form.qing_answer_count method because these requests tend to come in batches so better
-  # to fetch the counts for all qings on the form at once
   def data?
-    form.qing_answer_count(self).positive?
-  end
-
-  def answer_count
-    answers.count
+    answers.exists?
   end
 
   def conditions_changed?

--- a/app/models/questioning.rb
+++ b/app/models/questioning.rb
@@ -57,7 +57,7 @@ class Questioning < FormItem
     :first_leaf_option_node, :first_level_option_nodes, :has_options?, :hint, :level_count, :level, :levels,
     :min_max_error_msg, :multilevel?, :multimedia?, :name, :numeric?, :odk_constraint, :odk_name,
     :option_set_id, :option_set_id=, :option_set, :option_set=, :options, :preordered_option_nodes,
-    :printable?, :qtype_name, :qtype_name=, :qtype, :select_options,
+    :printable?, :qtype_name, :qtype_name=, :qtype,
     :sms_formatting_as_appendix?, :sms_formatting_as_text?, :standardized?, :subqings, :tags,
     :temporal?, :textual?, :title, :metadata_type, :reference, :select_multiple?,
     to: :question


### PR DESCRIPTION
I can't believe how simple of a fix this was. Checking existence using count is a bad idea it would appear! Makes sense in retrospect. 

Page loads for forms with lots of responses went from ~5 s to < 1 s.