### PR TITLE
11626: Fix SMTP for password reset

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,14 +87,7 @@ ELMO::Application.configure do
 
   config.action_mailer.delivery_method = :smtp
 
-  config.action_mailer.smtp_settings = {
-    address: Cnfg.smtp_address,
-    port: Cnfg.smtp_port,
-    domain: Cnfg.smtp_domain,
-    authentication: Cnfg.smtp_authentication,
-    user_name: Cnfg.smtp_user_name,
-    password: Cnfg.smtp_password
-  }
+  config.action_mailer.smtp_settings = Cnfg.smtp_options
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/lib/config_manager.rb
+++ b/lib/config_manager.rb
@@ -56,6 +56,14 @@ class ConfigManager
     ENV.fetch("NEMO_URL_PORT").to_i
   end
 
+  # Returns a hash of url options (port, protocol, host). Omits port if it's default for protocol.
+  def url_options
+    options = {protocol: url_protocol, host: url_host}
+    return options if url_protocol == "http" && url_port == 80 || url_protocol == "https" && url_port == 443
+    options[:port] = url_port
+    options
+  end
+
   def smtp_address
     ENV.fetch("NEMO_SMTP_ADDRESS")
   end
@@ -80,12 +88,17 @@ class ConfigManager
     ENV["NEMO_SMTP_PASSWORD"]
   end
 
-  # Returns a hash of url options (port, protocol, host). Omits port if it's default for protocol.
-  def url_options
-    options = {protocol: url_protocol, host: url_host}
-    return options if url_protocol == "http" && url_port == 80 || url_protocol == "https" && url_port == 443
-    options[:port] = url_port
-    options
+  # Returns a hash of SMTP options, omitting anything that's blank
+  # (otherwise, e.g. if `domain` is `nil` then all messages will be rejected).
+  def smtp_options
+    {
+      address: smtp_address,
+      port: smtp_port,
+      domain: smtp_domain,
+      authentication: smtp_authentication,
+      user_name: smtp_user_name,
+      password: smtp_password
+    }.select { |_key, value| value.presence }
   end
 
   def google_maps_key


### PR DESCRIPTION
Fix SMTP by filtering out blank SMTP options. Deployed in branch `release-12.2.1`.

Moved some code around but the only new thing is the `select` filter.

Specs failing due to this reason: https://github.com/thecartercenter/nemo/pull/819#discussion_r594769156