### PR TITLE
11593: Don't load Sentry in offline mode

### DIFF
--- a/.env
+++ b/.env
@@ -106,6 +106,10 @@ NEMO_FORCE_FRESH_ODATA=
 # For Scout monitoring (https://scoutapm.com)
 NEMO_SCOUT_KEY=XXXXXXXXXXXXXXXX
 
+# For Sentry debugging (https://sentry.io).
+# Please leave this as-is if you'd like to opt-in to bug fixes from the NEMO development team.
+NEMO_SENTRY_DSN="https://a81af08ff85042f3ae314e6c685853a3@o448595.ingest.sentry.io/5430181"
+
 # Theme variables for the default NEMO theme
 NEMO_NEMO_THEME_SITE_NAME=NEMO
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,7 +4,7 @@ Sentry.init do |config|
   # If the Sentry DSN remains nil, Sentry will be disabled.
   next if Rails.env.test? || Cnfg.offline_mode?
 
-  config.dsn = "https://a81af08ff85042f3ae314e6c685853a3@o448595.ingest.sentry.io/5430181"
+  config.dsn = Cnfg.sentry_dsn
   config.breadcrumbs_logger = [:active_support_logger]
   config.release = "nemo@#{Cnfg.system_version}"
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 Sentry.init do |config|
-  next if Rails.env.test?
+  # If the Sentry DSN remains nil, Sentry will be disabled.
+  next if Rails.env.test? || Cnfg.offline_mode?
 
   config.dsn = "https://a81af08ff85042f3ae314e6c685853a3@o448595.ingest.sentry.io/5430181"
   config.breadcrumbs_logger = [:active_support_logger]

--- a/lib/config_manager.rb
+++ b/lib/config_manager.rb
@@ -109,6 +109,10 @@ class ConfigManager
     ENV["NEMO_SCOUT_KEY"]
   end
 
+  def sentry_dsn
+    ENV["NEMO_SENTRY_DSN"]
+  end
+
   def allow_missionless_sms?
     ENV["NEMO_ALLOW_MISSIONLESS_SMS"] == "true"
   end


### PR DESCRIPTION
And make the DSN configurable because why not. That also makes it easier to manually disable if users want to.