### PR TITLE
11713: Add admin feature to re-cache form OData

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -147,6 +147,12 @@ class FormsController < ApplicationController
     redirect_to(index_url_with_context)
   end
 
+  def re_cache
+    Response.where(form_id: @form.id).update_all(dirty_json: true)
+    flash[:success] = t("operation.details.cache_odata")
+    redirect_after_status_change
+  end
+
   def go_live
     @form.update_status(:live)
     redirect_after_status_change

--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -14,6 +14,7 @@ module ActionLinks
           actions << :sms_guide
           actions << [:sms_console, h.new_sms_test_path] if can?(:create, Sms::Test)
         end
+        actions << [:re_cache, {method: :patch}] if can?(:re_cache, form)
       end
       actions << :destroy
       super(form, actions)

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -28,6 +28,7 @@ module IconHelper
     report_report: "bar-chart-o",
     response: "check-circle-o",
     return_to_draft: "undo",
+    re_cache: "refresh",
     hierarchicalresponse: "check-circle-o",
     setting: "gear",
     show: "file-o",

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -905,6 +905,7 @@ en:
         pause: "Pause"
         return_to_draft: "Return to Draft Status"
         print: "Print"
+        re_cache: "Re-cache OData"
       mission:
         new: "Create Mission"
       operation:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ ELMO::Application.routes.draw do
         patch "go-live", as: "go_live"
         patch "return-to-draft", as: "return_to_draft"
         patch "increment_version"
+        patch "re_cache"
       end
     end
 

--- a/spec/models/ability/form_ability_spec.rb
+++ b/spec/models/ability/form_ability_spec.rb
@@ -24,11 +24,23 @@ describe "abilities for forms" do
   context "mission mode" do
     let(:ability) { Ability.new(user: user, mode: "mission", mission: get_mission) }
 
+    context "for admin" do
+      let(:user) { create(:user, admin: true) }
+
+      it "should allow re-caching forms" do
+        expect(ability).to be_able_to(:re_cache, Form)
+      end
+    end
+
     context "for coordinator" do
       let(:user) { create(:user, role_name: "coordinator") }
 
       it "should be able to create and index" do
         %i[create index].each { |op| expect(ability).to be_able_to(op, Form) }
+      end
+
+      it "should not be able to re-cache" do
+        %i[re_cache].each { |op| expect(ability).not_to be_able_to(op, Form) }
       end
 
       context "when draft" do
@@ -75,6 +87,7 @@ describe "abilities for forms" do
       it "should be able to index but not create" do
         expect(ability).to be_able_to(:index, Form)
         expect(ability).not_to be_able_to(:create, Form)
+        expect(ability).not_to be_able_to(:re_cache, Form)
       end
 
       context "when draft" do


### PR DESCRIPTION
Context: [this Slack thread](https://sassafras.slack.com/archives/C02K5DWP2/p1617997475055600?thread_ts=1617825469.048200&cid=C02K5DWP2) with [this form](https://health.getnemo.org/en/m/malariamonthlyreporting/forms/917d5a48-6d71-4596-96fe-22789bb11683).

Related: I also added a stub server for debugging in https://github.com/thecartercenter/nemo/commit/31cb218c9eb74e9f4eb017bbb9b5f33644c00401.