### PR TITLE
11746: added rescue if duplicate files, added a test

### DIFF
--- a/app/models/utils/bulk_media_packager.rb
+++ b/app/models/utils/bulk_media_packager.rb
@@ -39,15 +39,15 @@ module Utils
 
     def download_and_zip_images
       FileUtils.mkdir_p(Rails.root.join(TMP_DIR))
-
       media_ids = media_objects_scope.pluck("media_objects.id")
-
       filename = "#{@operation.mission.compact_name}-media-#{Time.current.to_s(:filename_datetime)}.zip"
       zipfile_name = Rails.root.join(TMP_DIR, filename)
 
       Zip::File.open(zipfile_name, Zip::File::CREATE) do |zipfile|
         media_ids.each do |media_id|
           zip_media(::Media::Object.find(media_id).item, zipfile)
+        rescue Zip::EntryExistsError
+          next
         end
       end
       zipfile_name

--- a/spec/models/utils/bulk_media_packager_spec.rb
+++ b/spec/models/utils/bulk_media_packager_spec.rb
@@ -5,50 +5,80 @@ require "fileutils"
 require "zip"
 
 describe Utils::BulkMediaPackager do
-  let(:user) { create(:user, role_name: "coordinator") }
-  let(:operation) { create(:operation, creator: user) }
-  let!(:form) { create(:form, name: "foo", question_types: %w[image]) }
-  let!(:form2) { create(:form, name: "bar", question_types: %w[image]) }
+  context "happy paths" do
+    let(:user) { create(:user, role_name: "coordinator") }
+    let(:operation) { create(:operation, creator: user) }
+    let!(:form) { create(:form, name: "foo", question_types: %w[image]) }
+    let!(:form2) { create(:form, name: "bar", question_types: %w[image]) }
 
-  let(:media_jpg) { create(:media_image, :jpg) }
-  let(:media_png) { create(:media_image, :png) }
-  let(:media_tiff) { create(:media_image, :tiff) }
+    let(:media_jpg) { create(:media_image, :jpg) }
+    let(:media_png) { create(:media_image, :png) }
+    let(:media_tiff) { create(:media_image, :tiff) }
 
-  let!(:responses) do
-    [
-      create(:response, form: form, answer_values: [media_jpg]),
-      create(:response, form: form, answer_values: [media_png]),
-      create(:response, form: form2, answer_values: [media_tiff])
-    ]
-  end
-
-  describe "bulk image packager" do
-    it "should return the correct size of images" do
-      ability = Ability.new(user: operation.creator, mission: operation.mission)
-      packager = described_class.new(ability: ability, search: nil, operation: operation)
-      size = packager.calculate_media_size
-      expect(size).to equal(1_819_435)
+    let!(:responses) do
+      [
+        create(:response, form: form, answer_values: [media_jpg]),
+        create(:response, form: form, answer_values: [media_png]),
+        create(:response, form: form2, answer_values: [media_tiff])
+      ]
     end
 
-    it "should return the correct size of images with search" do
-      ability = Ability.new(user: operation.creator, mission: operation.mission)
-      packager = described_class.new(ability: ability, search: "form: foo", operation: operation)
-      size = packager.calculate_media_size
-      expect(size).to equal(855_939)
+    describe "bulk image packager" do
+      it "should return the correct size of images" do
+        ability = Ability.new(user: operation.creator, mission: operation.mission)
+        packager = described_class.new(ability: ability, search: nil, operation: operation)
+        size = packager.calculate_media_size
+        expect(size).to equal(1_819_435)
+      end
+
+      it "should return the correct size of images with search" do
+        ability = Ability.new(user: operation.creator, mission: operation.mission)
+        packager = described_class.new(ability: ability, search: "form: foo", operation: operation)
+        size = packager.calculate_media_size
+        expect(size).to equal(855_939)
+      end
+
+      it "should download, zip all the images, and cleanup" do
+        ability = Ability.new(user: operation.creator, mission: operation.mission)
+        packager = described_class.new(ability: ability, search: "form: foo", operation: operation)
+        results = packager.download_and_zip_images
+
+        expect(results.basename.to_s).to match(/#{operation.mission.compact_name}-media-.+.zip/)
+        expect(File.exist?(results.to_s)).to be(true)
+        expect(Dir["#{results.dirname}/*.jpg"].any?).to be(false)
+
+        Zip::File.open(results.to_s) do |zipfile|
+          zipfile.each do |file|
+            expect(file.name).to match(/nemo-.+-.+.(jpg|png|tiff)/)
+          end
+        end
+      end
     end
 
-    it "should download, zip all the images, and cleanup" do
-      ability = Ability.new(user: operation.creator, mission: operation.mission)
-      packager = described_class.new(ability: ability, search: "form: foo", operation: operation)
-      results = packager.download_and_zip_images
+    context "edge cases" do
+      let(:user) { create(:user, role_name: "coordinator") }
+      let(:operation) { create(:operation, creator: user) }
+      let!(:form) { create(:form, name: "foo", question_types: %w[image image]) }
+      let!(:form2) { create(:form, name: "bar", question_types: %w[image]) }
 
-      expect(results.basename.to_s).to match(/#{operation.mission.compact_name}-media-.+.zip/)
-      expect(File.exist?(results.to_s)).to be(true)
-      expect(Dir["#{results.dirname}/*.jpg"].any?).to be(false)
+      let(:media_jpg) { create(:media_image, :jpg) }
+      let(:media_png) { create(:media_image, :png) }
+      let(:media_tiff) { create(:media_image, :tiff) }
 
-      Zip::File.open(results.to_s) do |zipfile|
-        zipfile.each do |file|
-          expect(file.name).to match(/nemo-.+-.+.(jpg|png|tiff)/)
+      let!(:responses) do
+        [
+          create(:response, form: form, answer_values: [media_jpg, media_jpg]),
+          create(:response, form: form2, answer_values: [media_tiff])
+        ]
+      end
+
+      describe "with the same name" do
+        it "should fail gracefully" do
+          ability = Ability.new(user: operation.creator, mission: operation.mission)
+          packager = described_class.new(ability: ability, operation: operation)
+          results = packager.download_and_zip_images
+
+          expect(File.exist?(results.to_s)).to be(true)
         end
       end
     end


### PR DESCRIPTION
I'm not sure how the original case happened, perhaps there are some duplicate files? Anyhow this is the best I can think of to deal with this edge case, to just skip it if there is a duplicate.