### PR TITLE
[hotfix] 11830 include conditional qing codes in CSV exports

### DIFF
--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -14,6 +14,12 @@ module OData
       FormName: :string
     }.freeze
 
+    # These have been added on since an earlier full re-cache,
+    # and shouldn't be relied upon to exist on every old cached response.
+    RESPONSE_EXTRA_PROPERTIES = {
+      LastCached: :datetime
+    }.freeze
+
     GEOGRAPHIC_PROPERTIES = Answer::LOCATION_COLS.map do |key|
       [key.titleize.to_s, :decimal]
     end.to_h

--- a/app/models/o_data/simple_entities.rb
+++ b/app/models/o_data/simple_entities.rb
@@ -14,12 +14,6 @@ module OData
       FormName: :string
     }.freeze
 
-    # These have been added on since an earlier full re-cache,
-    # and shouldn't be relied upon to exist on every old cached response.
-    RESPONSE_EXTRA_PROPERTIES = {
-      LastCached: :datetime
-    }.freeze
-
     GEOGRAPHIC_PROPERTIES = Answer::LOCATION_COLS.map do |key|
       [key.titleize.to_s, :decimal]
     end.to_h

--- a/app/models/results/csv/header_map.rb
+++ b/app/models/results/csv/header_map.rb
@@ -34,13 +34,6 @@ module Results
         end
       end
 
-      # Forms with conditional logic that leads to a question NEVER being shown to users
-      # will never have that question code stored in their response tree.
-      # Ensure the headers still get added so that data analysts aren't confused.
-      def add_placeholders(placeholder_headers)
-        placeholder_headers.each { |h| add(h) }
-      end
-
       # Returns the index the given header maps to, or nil if not found.
       def index_for(header)
         map[header]

--- a/app/models/results/csv/header_map.rb
+++ b/app/models/results/csv/header_map.rb
@@ -34,16 +34,11 @@ module Results
         end
       end
 
-      def add_from_qcode(row)
-        if row["level_names"]
-          add_level_headers(row["code"], row["level_names"])
-        else
-          add(row["code"])
-        end
-
-        # If it's a select question that has coords, add cols for that.
-        return unless row["allow_coordinates"] && row["qtype_name"] != "select_multiple"
-        add_location_headers(row["code"], lat_lng_only: true)
+      # Forms with conditional logic that leads to a question NEVER being shown to users
+      # will never have that question code stored in their response tree.
+      # Ensure the headers still get added so that data analysts aren't confused.
+      def add_placeholders(placeholder_headers)
+        placeholder_headers.each { |h| add(h) }
       end
 
       # Returns the index the given header maps to, or nil if not found.
@@ -69,6 +64,18 @@ module Results
 
       def translate(header)
         I18n.t("response.csv_headers.#{header}")
+      end
+
+      def add_from_qcode(row)
+        if row["level_names"]
+          add_level_headers(row["code"], row["level_names"])
+        else
+          add(row["code"])
+        end
+
+        # If it's a select question that has coords, add cols for that.
+        return unless row["allow_coordinates"] && row["qtype_name"] != "select_multiple"
+        add_location_headers(row["code"], lat_lng_only: true)
       end
 
       def add_location_headers(code, lat_lng_only: false)

--- a/app/models/results/csv/header_map.rb
+++ b/app/models/results/csv/header_map.rb
@@ -29,14 +29,21 @@ module Results
           if row["qtype_name"] == "location"
             add_location_headers(row["code"])
           else
-            row["level_names"] ? add_level_headers(row["code"], row["level_names"]) : add(row["code"])
-
-            # If it's a select question that has coords, add cols for that.
-            if row["allow_coordinates"] && row["qtype_name"] != "select_multiple"
-              add_location_headers(row["code"], lat_lng_only: true)
-            end
+            add_from_qcode(row)
           end
         end
+      end
+
+      def add_from_qcode(row)
+        if row["level_names"]
+          add_level_headers(row["code"], row["level_names"])
+        else
+          add(row["code"])
+        end
+
+        # If it's a select question that has coords, add cols for that.
+        return unless row["allow_coordinates"] && row["qtype_name"] != "select_multiple"
+        add_location_headers(row["code"], lat_lng_only: true)
       end
 
       # Returns the index the given header maps to, or nil if not found.

--- a/app/models/results/csv/header_query.rb
+++ b/app/models/results/csv/header_query.rb
@@ -18,6 +18,8 @@ module Results
         SQL
       end
 
+      # Note: This will NOT include answers marked "not relevant" (e.g. skipped questions).
+      # These must be added separately.
       def from
         <<~SQL.squish
           FROM responses

--- a/spec/fixtures/response_csv/display_logic.csv
+++ b/spec/fixtures/response_csv/display_logic.csv
@@ -1,0 +1,2 @@
+ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,DecimalQ3,TextQ1
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,,0,-123.5,foo

--- a/spec/fixtures/response_csv/display_logic.csv
+++ b/spec/fixtures/response_csv/display_logic.csv
@@ -1,2 +1,2 @@
-ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,DecimalQ3,TextQ1
-*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,,0,-123.5,foo
+ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,DecimalQ3,TextQ1,IntegerQ2
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,,0,-123.5,foo,


### PR DESCRIPTION
~The main change here is that we now pull in `cached_json.keys` and include those in the CSV header~

^ That didn't actually work for all cases, but what does work is using `form.descendants` to get a list of all questions in the form.

See the spec file I added before and after the second commit to see the user-facing change here -- `IntegerQ2` is now present in the CSV headers even though it was never submitted as an answer (because the display logic hides it).

I will deploy this to the health server after specs pass; we can deploy this to all servers next cycle, no rush.