### PR TITLE
11878 Sentry for React

### DIFF
--- a/app/javascript/components/ErrorBoundary/__snapshots__/component.test.js.snap
+++ b/app/javascript/components/ErrorBoundary/__snapshots__/component.test.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders (default) 1`] = `"children"`;
+exports[`renders (default) 1`] = `
+<ErrorBoundary
+  message="message"
+>
+  children
+</ErrorBoundary>
+`;
 
-exports[`renders (error) 1`] = `<DangerousComponent />`;
+exports[`renders (error) 1`] = `
+<ErrorBoundary
+  message="message"
+>
+  <div
+    className="alert alert-danger"
+    role="alert"
+  >
+    message
+  </div>
+</ErrorBoundary>
+`;

--- a/app/javascript/components/ErrorBoundary/__snapshots__/component.test.js.snap
+++ b/app/javascript/components/ErrorBoundary/__snapshots__/component.test.js.snap
@@ -4,7 +4,15 @@ exports[`renders (default) 1`] = `
 <ErrorBoundary
   message="message"
 >
-  children
+  <ErrorBoundary
+    fallback={
+      <ErrorFallback
+        message="message"
+      />
+    }
+  >
+    children
+  </ErrorBoundary>
 </ErrorBoundary>
 `;
 
@@ -12,11 +20,23 @@ exports[`renders (error) 1`] = `
 <ErrorBoundary
   message="message"
 >
-  <div
-    className="alert alert-danger"
-    role="alert"
+  <ErrorBoundary
+    fallback={
+      <ErrorFallback
+        message="message"
+      />
+    }
   >
-    message
-  </div>
+    <ErrorFallback
+      message="message"
+    >
+      <div
+        className="alert alert-danger"
+        role="alert"
+      >
+        message
+      </div>
+    </ErrorFallback>
+  </ErrorBoundary>
 </ErrorBoundary>
 `;

--- a/app/javascript/components/ErrorBoundary/component.js
+++ b/app/javascript/components/ErrorBoundary/component.js
@@ -1,5 +1,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import * as Sentry from '@sentry/react';
+
+const ErrorFallback = ({ message }) => (
+  <div className="alert alert-danger" role="alert">
+    {message}
+  </div>
+);
 
 class ErrorBoundary extends Component {
   static propTypes = {
@@ -11,29 +18,13 @@ class ErrorBoundary extends Component {
     message: I18n.t('common.jsError'),
   };
 
-  state = {
-    hasError: false,
-  };
-
-  componentDidCatch(error, info) {
-    if (process.env.NODE_ENV !== 'test') {
-      console.error('[Boundary error]', error);
-      console.error('[Boundary info]', info);
-    }
-
-    this.setState({ hasError: true });
-  }
-
   render = () => {
-    const { hasError } = this.state;
     const { message, children } = this.props;
 
-    if (!hasError) return children;
-
     return (
-      <div className="alert alert-danger" role="alert">
-        {message}
-      </div>
+      <Sentry.ErrorBoundary fallback={<ErrorFallback message={message} />}>
+        {children}
+      </Sentry.ErrorBoundary>
     );
   };
 }

--- a/app/javascript/components/ErrorBoundary/component.js
+++ b/app/javascript/components/ErrorBoundary/component.js
@@ -8,6 +8,10 @@ const ErrorFallback = ({ message }) => (
   </div>
 );
 
+ErrorFallback.propTypes = {
+  message: PropTypes.string,
+};
+
 class ErrorBoundary extends Component {
   static propTypes = {
     message: PropTypes.string,

--- a/app/javascript/components/ErrorBoundary/component.test.js
+++ b/app/javascript/components/ErrorBoundary/component.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import Component from './component';
 
@@ -13,12 +13,12 @@ const DangerousComponent = () => {
 };
 
 it('renders (default)', () => {
-  const wrapper = shallow(<Component {...mockProps} />);
+  const wrapper = mount(<Component {...mockProps} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it('renders (error)', () => {
-  const wrapper = shallow(
+  const wrapper = mount(
     <Component {...mockProps}>
       <DangerousComponent />
     </Component>,

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,17 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
+import * as Sentry from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
+
+Sentry.init({
+  dsn: process.env.NEMO_SENTRY_DSN,
+  integrations: [new Integrations.BrowserTracing()],
+
+  // Percentage between 0.0 - 1.0.
+  tracesSampleRate: 1.0,
+});
+
 // Support component names relative to this directory:
 const componentRequireContext = require.context('components', true);
 const ReactRailsUJS = require('react_ujs');

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,13 +13,16 @@ import 'regenerator-runtime/runtime';
 import * as Sentry from '@sentry/react';
 import { Integrations } from '@sentry/tracing';
 
-Sentry.init({
-  dsn: process.env.NEMO_SENTRY_DSN,
-  integrations: [new Integrations.BrowserTracing()],
+const isOnline = !process.env.NEMO_OFFLINE_MODE || process.env.NEMO_OFFLINE_MODE === 'false';
+if (isOnline && process.env.NODE_ENV !== 'test') {
+  Sentry.init({
+    dsn: process.env.NEMO_SENTRY_DSN,
+    integrations: [new Integrations.BrowserTracing()],
 
-  // Percentage between 0.0 - 1.0.
-  tracesSampleRate: 1.0,
-});
+    // Percentage between 0.0 - 1.0.
+    tracesSampleRate: 1.0,
+  });
+}
 
 // Support component names relative to this directory:
 const componentRequireContext = require.context('components', true);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@babel/preset-react": "7.10.4",
     "@babel/runtime": "7.11.2",
     "@rails/webpacker": "4.2.2",
+    "@sentry/react": "6.11.0",
+    "@sentry/tracing": "6.11.0",
     "babel-loader": "8.1.0",
     "core-js": "3.6.5",
     "css-loader": "4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,6 +1251,16 @@
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
+"@sentry/browser@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.11.0.tgz#9e90bbc0488ebcdd1e67937d8d5b4f13c3f6dee0"
+  integrity sha512-Qr2QRA0t5/S9QQqxzYKvM9W8prvmiWuldfwRX4hubovXzcXLgUi4WK0/H612wSbYZ4dNAEcQbtlxFWJNN4wxdg==
+  dependencies:
+    "@sentry/core" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
 "@sentry/cli@1.58.0":
   version "1.58.0"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.58.0.tgz#b1609f10e71539951499866502b13bf3a270fe79"
@@ -1261,6 +1271,71 @@
     node-fetch "^2.6.0"
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
+
+"@sentry/core@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.11.0.tgz#40e94043afcf6407a109be26655c77832c64e740"
+  integrity sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
+  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
+  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/react@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.11.0.tgz#291a184b0f1ae75a78d592e78171f0a1c3609490"
+  integrity sha512-Qq57pqxE5VVsRp/ou+xv/R15ds54vv8F4/WbS+a4vEB1KqdX2NzfFDuKni5G+pZD4XNl9CI+LeUyiKtD4K/k7Q==
+  dependencies:
+    "@sentry/browser" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.11.0.tgz#9bd9287addea1ebc12c75b226f71c7713c0fac4f"
+  integrity sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==
+  dependencies:
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
+    tslib "^1.9.3"
+
+"@sentry/types@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
+  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
+
+"@sentry/utils@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
+  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
+  dependencies:
+    "@sentry/types" "6.11.0"
+    tslib "^1.9.3"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
@@ -5108,7 +5183,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -11094,6 +11169,11 @@ tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Record errors instead of ignoring them, since we have Sentry installed for Rails already.

This was prompted by Dottie's earlier suggestion that the date filter was disappearing (addressed in #854), which may happen if there's an error in React; until now, we wouldn't have any way to diagnose how frequently this occurs.