### PR TITLE
Add admin link to quick-view form responses odata

### DIFF
--- a/app/assets/stylesheets/global/_index_tables.scss
+++ b/app/assets/stylesheets/global/_index_tables.scss
@@ -1,4 +1,6 @@
 .index-links {
+  @include link-divider;
+
   margin-bottom: 10px;
 
   > a {
@@ -10,8 +12,6 @@
       color: $accent-color;
     }
   }
-
-  @include link-divider;
 }
 
 .index_table {

--- a/app/assets/stylesheets/global/_index_tables.scss
+++ b/app/assets/stylesheets/global/_index_tables.scss
@@ -11,11 +11,7 @@
     }
   }
 
-  .link-divider {
-    color: $light-border-color;
-    display: inline-block;
-    margin-#{$right}: 10px;
-  }
+  @include link-divider;
 }
 
 .index_table {

--- a/app/assets/stylesheets/variables/_mixins.scss
+++ b/app/assets/stylesheets/variables/_mixins.scss
@@ -1,4 +1,14 @@
+@mixin link-divider {
+  .link-divider {
+    color: $light-border-color;
+    display: inline-block;
+    margin-#{$right}: 10px;
+  }
+}
+
 @mixin top-action-links {
+  @include link-divider;
+
   margin-bottom: 10px;
 
   a {

--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -15,9 +15,16 @@ module ActionLinks
           actions << [:sms_console, h.new_sms_test_path] if can?(:create, Sms::Test)
         end
         actions << [:re_cache, {method: :patch}] if can?(:re_cache, form)
+        actions << [:view_raw_odata, {url: api_url(form)}] if can?(:view_raw_odata, form)
       end
       actions << :destroy
       super(form, actions)
+    end
+
+    private
+
+    def api_url(form)
+      "#{h.request.base_url}#{h.current_root_path}#{OData::BASE_PATH}/#{OData::FormDecorator.new(form).responses_url}"
     end
   end
 end

--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -27,7 +27,9 @@ module ActionLinks
     private
 
     def api_url(form)
-      "#{h.request.base_url}#{h.current_root_path}#{OData::BASE_PATH}/#{OData::FormDecorator.new(form).responses_url}"
+      base_path = "#{h.request.base_url}#{h.current_root_path}#{OData::BASE_PATH}"
+      responses_path = OData::FormDecorator.new(form).responses_url
+      "#{base_path}/#{responses_path}"
     end
   end
 end

--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -14,8 +14,11 @@ module ActionLinks
           actions << :sms_guide
           actions << [:sms_console, h.new_sms_test_path] if can?(:create, Sms::Test)
         end
-        actions << [:re_cache, {method: :patch}] if can?(:re_cache, form)
-        actions << [:view_raw_odata, {url: api_url(form)}] if can?(:view_raw_odata, form)
+        if can?(:re_cache, form) || can?(:view_raw_odata, form)
+          actions << link_divider
+          actions << [:re_cache, {method: :patch}] if can?(:re_cache, form)
+          actions << [:view_raw_odata, {url: api_url(form)}] if can?(:view_raw_odata, form)
+        end
       end
       actions << :destroy
       super(form, actions)

--- a/app/decorators/action_links/link_builder.rb
+++ b/app/decorators/action_links/link_builder.rb
@@ -18,8 +18,12 @@ module ActionLinks
       return nil if object.new_record?
       h.content_tag(:div, class: "top-action-links d-print-none") do
         safe_str << actions.map do |action|
+          # It may already be HTML.
+          next action if action.instance_of?(ActiveSupport::SafeBuffer)
+
           action, url, method, data = unpack_action(action)
           next unless url && can?(action, object)
+
           data[:confirm] = delete_warning if action == :destroy
           h.link_to(h.icon_tag(action) << translate_action(action), url,
             method: method, data: data, class: "#{action.to_s.dasherize}-link")
@@ -62,6 +66,10 @@ module ActionLinks
     def translate_action(action)
       t("action_links.#{action}",
         default: :"action_links.models.#{object.model_name.i18n_key}.#{action}")
+    end
+
+    def link_divider
+      h.content_tag(:span, "|", class: "link-divider")
     end
 
     def delete_warning

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -29,6 +29,7 @@ module IconHelper
     response: "check-circle-o",
     return_to_draft: "undo",
     re_cache: "refresh",
+    view_raw_odata: "database",
     hierarchicalresponse: "check-circle-o",
     setting: "gear",
     show: "file-o",

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -105,6 +105,7 @@ class Ability
       can(%i[update login_instructions change_assignments], User, id: user.id)
 
       can(%i[re_cache], Form)
+      can(%i[view_raw_odata], Form)
     end
 
     # Only admins can give/take admin (adminify) to/from others, but not from themselves
@@ -167,6 +168,7 @@ class Ability
       # This is intentionally redundant with `manage` as we're slowly migrating to explicit permissions.
       can(:change_status, Form, mission_id: mission.id)
       cannot(:re_cache, Form)
+      cannot(:view_raw_odata, Form)
       can(:update_core, OptionSet, mission_id: mission.id)
 
       can(:condition_form, Constraint, mission_id: mission.id)

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -906,6 +906,7 @@ en:
         return_to_draft: "Return to Draft Status"
         print: "Print"
         re_cache: "Re-cache OData"
+        view_raw_odata: "View raw OData"
       mission:
         new: "Create Mission"
       operation:

--- a/spec/models/ability/form_ability_spec.rb
+++ b/spec/models/ability/form_ability_spec.rb
@@ -30,6 +30,10 @@ describe "abilities for forms" do
       it "should allow re-caching forms" do
         expect(ability).to be_able_to(:re_cache, Form)
       end
+
+      it "should allow viewing raw odata link" do
+        expect(ability).to be_able_to(:view_raw_odata, Form)
+      end
     end
 
     context "for coordinator" do
@@ -41,6 +45,10 @@ describe "abilities for forms" do
 
       it "should not be able to re-cache" do
         %i[re_cache].each { |op| expect(ability).not_to be_able_to(op, Form) }
+      end
+
+      it "should not be able to view raw odata link" do
+        %i[view_raw_odata].each { |op| expect(ability).not_to be_able_to(op, Form) }
       end
 
       context "when draft" do
@@ -88,6 +96,7 @@ describe "abilities for forms" do
         expect(ability).to be_able_to(:index, Form)
         expect(ability).not_to be_able_to(:create, Form)
         expect(ability).not_to be_able_to(:re_cache, Form)
+        expect(ability).not_to be_able_to(:view_raw_odata, Form)
       end
 
       context "when draft" do


### PR DESCRIPTION
I do this constantly, in development and production, so this is a nice convenient link for admins:

![Screen Shot 2021-08-16 at 19 04 53](https://user-images.githubusercontent.com/2047062/129652181-130aa015-a7e7-43ad-8e7e-3735d63ea792.png)