### PR TITLE
Add clone declaration for SkipRule conditions association

### DIFF
--- a/app/models/skip_rule.rb
+++ b/app/models/skip_rule.rb
@@ -45,6 +45,8 @@ class SkipRule < ApplicationRecord
                {name: :dest_item, second_pass: true}
              ]
 
+  clone_options follow: %i[conditions]
+
   def all_fields_blank?
     destination.blank? && dest_item.blank? && conditions.all?(&:all_fields_blank?)
   end


### PR DESCRIPTION
This was an unfortunate ommission. This code doesn't currently have test coverage because it was always kind of a skunkworks thing. Would be good to add some at some point. It would be interesting since you have to have to separate databases. Or perhaps you could just do the export, blow away the test database mid-test, then import and check. But in any case doing that is beyond the scope of this quick fix.