### PR TITLE
12038 changelog link

### DIFF
--- a/app/assets/stylesheets/global/_layout.scss
+++ b/app/assets/stylesheets/global/_layout.scss
@@ -209,10 +209,4 @@ header {
   #locale_form {
     display: none;
   }
-
-  div.site_by {
-    margin-top: 10px;
-    padding: 3px;
-    text-align: right;
-  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -119,20 +119,23 @@
   </div>
 
   <div id="footer" class="d-print-none">
+    <div class="footer-row">
+      <%= link_to(t("layout.change_language"), "#", :id => "locale_form_link") %>
 
-    <%= link_to(t("layout.change_language"), "#", :id => "locale_form_link") %>
-
-    <%= form_tag(nil, :id => "locale_form") do %>
-      <%# We can't change language unless the request is GET since no way to redirect browser to POST, etc. %>
-      <%# So we disable with message in that case. %>
-      <%= select_tag(:locale, options_for_select(I18n.available_locales.map{|l| [language_name(l), l]}, I18n.locale),
-        class: 'form-control', disabled: !request.get?, title: request.get? ? '' : I18n.t('layout.locale_change_get_only')) %>
-    <% end %>
-
-    &nbsp;|&nbsp;
-    <%= t("layout.time_zone") %>: <%= Time.zone.to_s %> &nbsp;|&nbsp;
-    <%= t("layout.system_version") %>: <%= Cnfg.system_version %> &nbsp;|&nbsp;
-    <%= link_to(t('layout.about', site_name: current_mission_config.site_name), 'http://getnemo.org') %>
+      <%= form_tag(nil, :id => "locale_form") do %>
+        <%# We can't change language unless the request is GET since no way to redirect browser to POST, etc. %>
+        <%# So we disable with message in that case. %>
+        <%= select_tag(:locale, options_for_select(I18n.available_locales.map{|l| [language_name(l), l]}, I18n.locale),
+          class: 'form-control', disabled: !request.get?, title: request.get? ? '' : I18n.t('layout.locale_change_get_only')) %>
+      <% end %>
+      &nbsp;|&nbsp;
+      <%= t("layout.time_zone") %>: <%= Time.zone.to_s %>
+      &nbsp;|&nbsp;
+      <%= t("layout.system_version") %>: <%= Cnfg.system_version %>
+    </div>
+    <div class="footer-row">
+      <%= link_to(t('layout.about', site_name: current_mission_config.site_name), 'https://getnemo.org') %>
+    </div>
   </div>
 
   <div id="glb-load-ind">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -134,11 +134,11 @@
       <%= t("layout.system_version") %>: <%= Cnfg.system_version %>
     </div>
     <div class="footer-row">
-      <%= link_to(t('layout.about', site_name: current_mission_config.site_name), 'https://getnemo.org') %>
+      <%= link_to(t("layout.about", site_name: current_mission_config.site_name), "https://getnemo.org", target: "_blank", rel: "noopener") %>
       &nbsp;|&nbsp;
-      <%= link_to(t('common.docs'), 'https://getnemo.readthedocs.io') %>
+      <%= link_to(t("common.docs"), "https://getnemo.readthedocs.io", target: "_blank", rel: "noopener") %>
       &nbsp;|&nbsp;
-      <%= link_to(t('layout.changelog'), 'https://github.com/thecartercenter/nemo/releases') %>
+      <%= link_to(t("layout.changelog"), "https://github.com/thecartercenter/nemo/releases", target: "_blank", rel: "noopener") %>
     </div>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -135,6 +135,10 @@
     </div>
     <div class="footer-row">
       <%= link_to(t('layout.about', site_name: current_mission_config.site_name), 'https://getnemo.org') %>
+      &nbsp;|&nbsp;
+      <%= link_to(t('common.docs'), 'https://getnemo.readthedocs.io') %>
+      &nbsp;|&nbsp;
+      <%= link_to(t('layout.changelog'), 'https://github.com/thecartercenter/nemo/releases') %>
     </div>
   </div>
 

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -868,6 +868,7 @@ en:
     about: "About %{site_name}"
     actions: "Actions"
     are_you_sure: "Are you sure?"
+    changelog: "Changelog"
     change_language: "Change Language"
     created_by: "Created by"
     copy_to_clipboard: "Copy to Clipboard"


### PR DESCRIPTION
Old:
<img width="616" alt="Screen Shot 2021-11-10 at 09 47 12" src="https://user-images.githubusercontent.com/2047062/141165809-9dbc2477-5c65-40ea-8b18-30334c4e44b6.png">

New:
<img width="449" alt="Screen Shot 2021-11-10 at 09 46 59" src="https://user-images.githubusercontent.com/2047062/141165816-00474049-0928-4cbc-806b-1a82457c16ff.png">

Plus a redundant link to the docs because why not?