### PR TITLE
12055: added question code to xml

### DIFF
--- a/app/models/utils/xml_packager.rb
+++ b/app/models/utils/xml_packager.rb
@@ -31,7 +31,10 @@ module Utils
       xml_string = response.odk_xml.download
       qings = response.form.questionings
       # replace qing id with human readable name
-      qings.each { |q| xml_string.gsub!("qing#{q.id}", q.name) }
+      qings.each do |q|
+        human_readable = "code='#{q.code}' question='#{q.name}'"
+        xml_string.gsub!("qing#{q.id}", human_readable)
+      end
       xml_string
     end
 

--- a/app/models/utils/xml_packager.rb
+++ b/app/models/utils/xml_packager.rb
@@ -32,8 +32,9 @@ module Utils
       qings = response.form.questionings
       # replace qing id with human readable name
       qings.each do |q|
-        human_readable = "code='#{q.code}' question='#{q.name}'"
-        xml_string.gsub!("qing#{q.id}", human_readable)
+        human_readable = "<#{q.code} question='#{q.name}'>"
+        xml_string.gsub!("<qing#{q.id}>", human_readable)
+        xml_string.gsub!("</qing#{q.id}>", "</#{q.code}>")
       end
       xml_string
     end

--- a/spec/models/utils/xml_packager_spec.rb
+++ b/spec/models/utils/xml_packager_spec.rb
@@ -39,9 +39,11 @@ describe Utils::XmlPackager do
     end
 
     it "should replace the xml file with question names" do
+      q1 = form.c[0].code
+      q2 = form.c[1].code
       human_readable_xml = packager.human_readable_xml(response)
-      expect(human_readable_xml).to include("<code='TextQ1' question='firstname'>rhys</code='TextQ1' question='firstname'>")
-      expect(human_readable_xml).to include("<code='TextQ2' question='lastname'>dimond</code='TextQ2' question='lastname'>")
+      expect(human_readable_xml).to include("<#{q1} question='firstname'>rhys</#{q1}>")
+      expect(human_readable_xml).to include("<#{q2} question='lastname'>dimond</#{q2}>")
     end
 
     it "should zip one xml response" do
@@ -68,9 +70,10 @@ describe Utils::XmlPackager do
     end
 
     it "should have the correct xml" do
+      q1 = form.c[1].c[0].code
       human_readable_xml = packager.human_readable_xml(response)
-      expect(human_readable_xml).to include("<code='TextQ2' question='firstname'>Rhys</code='TextQ2' question='firstname'>")
-      expect(human_readable_xml).to include("<code='TextQ2' question='firstname'>Wynn</code='TextQ2' question='firstname'>")
+      expect(human_readable_xml).to include("<#{q1} question='firstname'>Wynn</#{q1}>")
+      expect(human_readable_xml).to include("<#{q1} question='firstname'>Rhys</#{q1}>")
     end
   end
 end

--- a/spec/models/utils/xml_packager_spec.rb
+++ b/spec/models/utils/xml_packager_spec.rb
@@ -40,8 +40,8 @@ describe Utils::XmlPackager do
 
     it "should replace the xml file with question names" do
       human_readable_xml = packager.human_readable_xml(response)
-      expect(human_readable_xml).to include("<firstname>rhys</firstname>")
-      expect(human_readable_xml).to include("<lastname>dimond</lastname>")
+      expect(human_readable_xml).to include("<code='TextQ1' question='firstname'>rhys</code='TextQ1' question='firstname'>")
+      expect(human_readable_xml).to include("<code='TextQ2' question='lastname'>dimond</code='TextQ2' question='lastname'>")
     end
 
     it "should zip one xml response" do
@@ -69,8 +69,8 @@ describe Utils::XmlPackager do
 
     it "should have the correct xml" do
       human_readable_xml = packager.human_readable_xml(response)
-      expect(human_readable_xml).to include("<firstname>Rhys</firstname>")
-      expect(human_readable_xml).to include("<firstname>Wynn</firstname>")
+      expect(human_readable_xml).to include("<code='TextQ2' question='firstname'>Rhys</code='TextQ2' question='firstname'>")
+      expect(human_readable_xml).to include("<code='TextQ2' question='firstname'>Wynn</code='TextQ2' question='firstname'>")
     end
   end
 end


### PR DESCRIPTION
Tweak to include question code in downloadable response xml.

Now looks like this:
```<code='TextQ2' question='firstname'>Wynn</code='TextQ2' question='firstname'>```