### PR TITLE
12056: Don't translate and/or constraints

### DIFF
--- a/app/decorators/odk/condition_group_decorator.rb
+++ b/app/decorators/odk/condition_group_decorator.rb
@@ -7,7 +7,7 @@ module ODK
       if members.empty?
         negate? ? "false()" : nil
       else
-        conjunction = true_if == "all_met" ? I18n.t("common.and") : I18n.t("common.or")
+        conjunction = true_if == "all_met" ? I18n.t("common.AND") : I18n.t("common.OR")
         result = decorated_members.map { |m| "(#{m.to_odk})" }.join(" #{conjunction} ")
         negate? ? "not(#{result})" : result
       end

--- a/app/decorators/odk/condition_group_decorator.rb
+++ b/app/decorators/odk/condition_group_decorator.rb
@@ -7,7 +7,7 @@ module ODK
       if members.empty?
         negate? ? "false()" : nil
       else
-        conjunction = true_if == "all_met" ? I18n.t("common.AND") : I18n.t("common.OR")
+        conjunction = true_if == "all_met" ? "and" : "or"
         result = decorated_members.map { |m| "(#{m.to_odk})" }.join(" #{conjunction} ")
         negate? ? "not(#{result})" : result
       end

--- a/db/migrate/20211206000000_render_existing_live_forms.rb
+++ b/db/migrate/20211206000000_render_existing_live_forms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenderExistingLiveForms < ActiveRecord::Migration[6.1]
+  def up
+    Form.published.find_each { |f| ODK::FormRenderJob.perform_now(f) }
+  end
+end

--- a/db/migrate/20211206000000_render_existing_live_forms2.rb
+++ b/db/migrate/20211206000000_render_existing_live_forms2.rb
@@ -2,6 +2,10 @@
 
 class RenderExistingLiveForms2 < ActiveRecord::Migration[6.1]
   def up
-    Form.published.find_each { |f| ODK::FormRenderJob.perform_now(f) }
+    puts "Rendering #{Form.published.count} forms..."
+    Form.published.find_each do |f|
+      puts "Rendering #{f.name}..."
+      ODK::FormRenderJob.perform_now(f)
+    end
   end
 end

--- a/db/migrate/20211206000000_render_existing_live_forms2.rb
+++ b/db/migrate/20211206000000_render_existing_live_forms2.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RenderExistingLiveForms < ActiveRecord::Migration[6.1]
+class RenderExistingLiveForms2 < ActiveRecord::Migration[6.1]
   def up
     Form.published.find_each { |f| ODK::FormRenderJob.perform_now(f) }
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_05_130501) do
+ActiveRecord::Schema.define(version: 2021_12_06_000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Very simple fix for a very tricky bug (these strings should never actually have been translated using i18n, since they're meant for computers to read).

I have already manually fixed the forms in question by running ODK::FormRenderJob in the server console.

I'm going to hotfix to health right now; let's chat at standup tomorrow about whether this is worth hotfixing to the rest, since it only applies to new standard form copies on missions that have non-english default languages.