### PR TITLE
Easy prod deployments with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ruby:2.7.5
+RUN apt-get update -qq \
+    && apt-get install -y nodejs postgresql-client
+COPY . /nemo/
+
+RUN echo 'export RAILS_ENV=production' >> ~/.bashrc \
+    && exec $SHELL
+    
+WORKDIR /nemo/
+
+COPY config/database.yml.docker /nemo/config/database.yml
+COPY docs/memcached.conf /etc/
+
+RUN bundle install --without development test --deployment
+
+# RUN bundle exec"0 0 * * *" -i nemo # FIXME
+
+
+
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+# Configure the main process to run when running the image
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/config/database.yml.docker
+++ b/config/database.yml.docker
@@ -1,15 +1,17 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 5
   host: db
   username: postgres
   password: password
+  pool: 5
+  database: nemo_db
 
-test:
-  <<: *default
-  database: nemo_test
+# development:
+#   <<: *default
+#   database: app_development
 
-development:
-  <<: *default
-  database: nemo_development
+
+# test:
+#   <<: *default
+#   database: app_test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  db:
+    image: postgres:12
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+  web:
+    build: .
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/nemo
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db

--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -385,7 +385,7 @@ See the [ActiveStorage Pull Request](https://github.com/thecartercenter/nemo/pul
 1. Run `rake db:seed`.
 1. You may delete the `local_config.rb`, `settings.local.yml`, `.rbenv-vars`, and `/config/settings/themes/custom.yml` files at this point, as everything is unified in `.env.*`.
 
-#### Upgrading to v12.19
+#### Upgrading to v12.21
 
 We've upgraded our node version to v16. After pulling the latest code:
 
@@ -394,7 +394,7 @@ We've upgraded our node version to v16. After pulling the latest code:
 1. Run `nvm use` to switch
 1. Run `rm -rf node_modules` to clean up
 1. Run `yarn install` to install fresh
-1. As the privileged user, run `sudo $EDITOR /etc/systemd/system/delayed-job.service` and completely overwrite it with the new contents of [delayed-job.service](/docs/delayed-job.service)
+1. As the privileged user, run `sudo $EDITOR /etc/systemd/system/delayed-job.service` and completely overwrite it with the new contents of [delayed-job.service](/docs/delayed-job.service), then run `sudo systemctl daemon-reload`
 1. Restart via `sudo systemctl restart delayed-job && sudo systemctl restart nginx` and everything should be working again
 
 #### Upgrading to latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /app/tmp/pids/server.pid
+
+bundle exec rake db:schema:load
+bundle exec rake db:seed
+bundle exec rake assets:precompile
+bundle exec rake db:create_admin
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
This PR aims to add working Docker functionality, allowing for easy, repeatedable prod deployments.

My idea is to...
1. SSH into a VM
2. Adjust configurations
3. `docker-compose build`
4. `docker-compose up`

No guarantees on this, as this is my first this is my first time dealing with Ruby (and Rails), but I wanted to make any changes public so that if anyone had any suggestions or ideas they could could post them. I'll keep this PR description up-to-date as I go.

#865 