### PR TITLE
12129: prevent underscores in form titles

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -77,10 +77,9 @@ class Form < ApplicationRecord
 
   after_save :update_minimum
 
-  # rubocop:disable Style/RegexpLiteral
-  # Do not allow any slashes, parenthesis, underscores, or pipes as this breaks the API
-  validates :name, presence: true, length: {maximum: 32}, format: {without: /[\/()\\|_]/}
-  # rubocop:enable Style/RegexpLiteral
+  # Disallow specific characters or symbol-only names such as `***` which all break Power BI
+  # (documented at https://github.com/thecartercenter/nemo/pull/895).
+  validates :name, presence: true, length: {maximum: 32}, format: {without: %r{([/%_]|\A\W+\z)}}
 
   validate :name_unique_per_mission
   validates_with Forms::DynamicPatternValidator, field_name: :default_response_name

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -78,8 +78,8 @@ class Form < ApplicationRecord
   after_save :update_minimum
 
   # rubocop:disable Style/RegexpLiteral
-  # Do not allow any slashes, parenthesis, or pipes as this breaks the API
-  validates :name, presence: true, length: {maximum: 32}, format: {without: /[\/()\\|]/}
+  # Do not allow any slashes, parenthesis, underscores, or pipes as this breaks the API
+  validates :name, presence: true, length: {maximum: 32}, format: {without: /[\/()\\|_]/}
   # rubocop:enable Style/RegexpLiteral
 
   validate :name_unique_per_mission

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -71,25 +71,42 @@ describe Form do
     end
 
     context "form name" do
-      describe "form name with invalid characters" do
-        let(:form) { build(:form, name: "abc|()/") }
+      describe "with slash" do
+        let(:form) { build(:form, name: "abc / 123") }
         it "should be invalid" do
           expect(form).to_not(be_valid)
         end
       end
-      describe "form name with alphanumeric and a space" do
+
+      describe "with symbols only" do
+        let(:form) { build(:form, name: "***") }
+        it "should be invalid" do
+          expect(form).to_not(be_valid)
+        end
+      end
+
+      describe "with symbols and letters" do
+        let(:form) { build(:form, name: "*a*") }
+        it "should be valid" do
+          expect(form).to be_valid
+        end
+      end
+
+      describe "with alphanumeric and a space" do
         let(:form) { build(:form, name: "Bert 123") }
         it "should be valid" do
           expect(form).to be_valid
         end
       end
-      describe "Form with an underscore" do
+
+      describe "with an underscore" do
         let(:form) { build(:form, name: "New_form123") }
         it "should be invalid" do
           expect(form).to_not(be_valid)
         end
       end
-      describe "from with letters with accents" do
+
+      describe "with letters with accents" do
         let(:form) { build(:form, name: "Más rès forma de añoç") }
         it "should be valid" do
           expect(form).to be_valid

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -83,6 +83,18 @@ describe Form do
           expect(form).to be_valid
         end
       end
+      describe "Form with an underscore" do
+        let(:form) { build(:form, name: "New_form123") }
+        it "should be invalid" do
+          expect(form).to_not(be_valid)
+        end
+      end
+      describe "from with letters with accents" do
+        let(:form) { build(:form, name: "Más rès forma de añoç") }
+        it "should be valid" do
+          expect(form).to be_valid
+        end
+      end
     end
   end
 


### PR DESCRIPTION
follow-up to #849 (see also notes in https://redmine.sassafras.coop/issues/10826)