### PR TITLE
12143 response serialization improvements

### DIFF
--- a/app/controllers/responses_controller.rb
+++ b/app/controllers/responses_controller.rb
@@ -240,8 +240,7 @@ class ResponsesController < ApplicationController
     rescue SubmissionError => e
       render_xml_submission_failure(e, :unprocessable_entity)
     rescue ActiveRecord::SerializationFailure => e
-      Sentry.capture_message("Ignored parallel duplicate")
-      render_xml_submission_failure(e, :created)
+      render_xml_submission_failure(e, :service_unavailable)
     end
   end
 

--- a/app/models/odk/response_saver.rb
+++ b/app/models/odk/response_saver.rb
@@ -3,7 +3,8 @@
 module ODK
   # Saves responses and is responsible for handling serialization and duplicate errors
   class ResponseSaver
-    MAX_TRIES = 10
+    # The more tries, the more likely it is to eventually succeed
+    MAX_TRIES = 12
 
     def self.save_with_retries!(params)
       tries = 0
@@ -18,7 +19,14 @@ module ODK
         break
       rescue ActiveRecord::SerializationFailure => e
         tries += 1
+
+        # Note for future: Do we still need to destroy the blank response in this case?
+        # See notes related to https://redmine.sassafras.coop/issues/12142.
         raise e if tries >= MAX_TRIES
+
+        # Delay a short, random number of milliseconds
+        # to allow different requests to try in various orders.
+        sleep(rand(1..100) / 1000.0)
       end
     end
   end

--- a/app/models/odk/response_saver.rb
+++ b/app/models/odk/response_saver.rb
@@ -4,8 +4,6 @@ module ODK
   # Saves responses and is responsible for handling serialization and duplicate errors
   class ResponseSaver
     MAX_TRIES = 10
-    # For testing race conditions, stubbed in tests
-    TEST_SLEEP_TIMER = 0
 
     def self.save_with_retries!(params)
       tries = 0
@@ -15,7 +13,6 @@ module ODK
             Sentry.capture_message("Ignored parallel duplicate")
             return
           end
-          sleep(TEST_SLEEP_TIMER)
           params[:response].save!(validate: false)
         end
         break

--- a/app/models/odk/response_saver.rb
+++ b/app/models/odk/response_saver.rb
@@ -5,14 +5,17 @@ module ODK
   class ResponseSaver
     MAX_TRIES = 10
     # For testing race conditions, stubbed in tests
-    SLEEP_TIMER = 0
+    TEST_SLEEP_TIMER = 0
 
     def self.save_with_retries!(params)
       tries = 0
       loop do
         ActiveRecord::Base.transaction(isolation: :serializable) do
-          return if ODK::ResponseParser.duplicate?(params[:submission_file], params[:user_id])
-          sleep(SLEEP_TIMER)
+          if ODK::ResponseParser.duplicate?(params[:submission_file], params[:user_id])
+            Sentry.capture_message("Ignored parallel duplicate")
+            return
+          end
+          sleep(TEST_SLEEP_TIMER)
           params[:response].save!(validate: false)
         end
         break

--- a/spec/fixtures/odk/responses/nested_group_form_response_duplicate.xml
+++ b/spec/fixtures/odk/responses/nested_group_form_response_duplicate.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' ?>
+<data id="*form1*" version="*formver1*" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+  <*itemcode1*>*value1*</*itemcode1*>
+  <*itemcode2*>
+    <header/>
+    <*itemcode3*>*value2*</*itemcode3*>
+    <*itemcode4*>
+      <header/>
+      <*itemcode5*>*value3*</*itemcode5*>
+      <*itemcode6*>*value4*</*itemcode6*>
+    </*itemcode4*>
+    <*itemcode4*>
+      <header/>
+      <*itemcode5*>*value5*</*itemcode5*>
+      <*itemcode6*>*value6*</*itemcode6*>
+    </*itemcode4*>
+  </*itemcode2*>
+  <*itemcode2*>
+    <header/>
+    <*itemcode3*>*value7*</*itemcode3*>
+    <*itemcode4*>
+      <header/>
+      <*itemcode5*>*value8*</*itemcode5*>
+      <*itemcode6*>*value9*</*itemcode6*>
+    </*itemcode4*>
+  </*itemcode2*>
+</data>

--- a/spec/models/odk/response_saver_spec.rb
+++ b/spec/models/odk/response_saver_spec.rb
@@ -20,11 +20,11 @@ describe ODK::ResponseSaver do
     let!(:form1) { create(:form, :live, mission: mission, question_types: question_types) }
     let!(:formver) { create(:form_version, code: "abc", number: "202211", form: form1) }
     let(:r1_path) { "tmp/odk/responses/simple_response/simple_response.xml" }
-    let(:r1) do
+    let!(:r1) do
       build(:response, :with_odk_attachment, xml_path: r1_path, form: form1,
                                              answer_values: xml_values, user_id: user.id)
     end
-    let(:r2) do
+    let!(:r2) do
       # Duplicate.
       build(:response, :with_odk_attachment, xml_path: r1_path, form: form1,
                                              answer_values: xml_values, user_id: user.id)
@@ -33,7 +33,6 @@ describe ODK::ResponseSaver do
 
     before do
       stub_const(ODK::ResponseSaver, "MAX_TRIES", 0)
-      stub_const(ODK::ResponseSaver, "TEST_SLEEP_TIMER", 1)
     end
 
     it "should return a database serialization error", database_cleaner: :truncate do
@@ -51,9 +50,6 @@ describe ODK::ResponseSaver do
         end
 
         thread2 = Thread.new do
-          # wait until the first thread is sleepin
-          sleep(0.5)
-
           ODK::ResponseSaver.save_with_retries!(
             response: r2,
             submission_file: upload,

--- a/spec/models/odk/response_saver_spec.rb
+++ b/spec/models/odk/response_saver_spec.rb
@@ -8,7 +8,7 @@ describe ODK::ResponseSaver do
   let(:mission) { create(:mission) }
   let(:user) { create(:user, role_name: "enumerator", mission: mission) }
   let(:fixture_name) { "single_question" }
-  let(:xml) { prepare_odk_response_fixture(fixture_name, form, values: [1], formver: formver) }
+  let(:xml) { prepare_odk_response_fixture(fixture_name, form1, values: [1], formver: formver) }
   let(:file) { Tempfile.new.tap { |f| f.write(xml) && f.rewind } }
   let(:upload) { Rack::Test::UploadedFile.new(file, "text/xml") }
   let(:request_params) { {xml_submission_file: upload, format: "xml"} }
@@ -21,14 +21,13 @@ describe ODK::ResponseSaver do
     let!(:formver) { create(:form_version, code: "abc", number: "202211", form: form1) }
     let(:r1_path) { "tmp/odk/responses/simple_response/simple_response.xml" }
     let(:r1) do
-      build(
-        :response,
-        :with_odk_attachment,
-        xml_path: r1_path,
-        form: form1,
-        answer_values: xml_values,
-        user_id: user.id
-      )
+      build(:response, :with_odk_attachment, xml_path: r1_path, form: form1,
+                                             answer_values: xml_values, user_id: user.id)
+    end
+    let(:r2) do
+      # Duplicate.
+      build(:response, :with_odk_attachment, xml_path: r1_path, form: form1,
+                                             answer_values: xml_values, user_id: user.id)
     end
     let!(:question_types) { %w[text text text text] }
 
@@ -40,9 +39,6 @@ describe ODK::ResponseSaver do
     it "should return a database serialization error", database_cleaner: :truncate do
       # make odk
       prepare_odk_response_fixture("simple_response", form1, values: xml_values, formver: "202211")
-      r1_path = Rails.root.join("tmp/odk/responses/simple_response/simple_response.xml")
-      upload = Rack::Test::UploadedFile.new(r1_path, "text/xml")
-      checksum = ODK::ResponseParser.compute_checksum_in_chunks(upload)
       e = nil
 
       begin
@@ -57,26 +53,21 @@ describe ODK::ResponseSaver do
         thread2 = Thread.new do
           # wait until the first thread is sleepin
           sleep(0.5)
-          insert_response_via_second_db_connection(checksum)
+
+          ODK::ResponseSaver.save_with_retries!(
+            response: r2,
+            submission_file: upload,
+            user_id: user.id
+          )
         end
 
         thread1.join
         thread2.join
       rescue ActiveRecord::SerializationFailure => e
+        expect(Response.count).to eq(1)
         expect(ActiveStorage::Blob.all.count).to eq(1)
         expect(e.class).to eq(ActiveRecord::SerializationFailure)
       end
     end
-  end
-
-  def insert_response_via_second_db_connection(checksum)
-    db = ActiveRecord::Base.connection_pool.checkout
-    db.execute("start transaction isolation level serializable;")
-    db.execute("select * from active_storage_blobs WHERE checksum='#{checksum}';")
-    db.execute("INSERT INTO active_storage_blobs
-      (checksum, byte_size, content_type, filename, key, service_name, created_at)
-      VALUES ('#{checksum}', 10000, 'application/xml', 'simple_response.xml', 'abc123', 'test', NOW());")
-    db.execute("COMMIT;")
-    ActiveRecord::Base.connection_pool.checkin(db)
   end
 end

--- a/spec/models/odk/response_saver_spec.rb
+++ b/spec/models/odk/response_saver_spec.rb
@@ -34,7 +34,7 @@ describe ODK::ResponseSaver do
 
     before do
       stub_const(ODK::ResponseSaver, "MAX_TRIES", 0)
-      stub_const(ODK::ResponseSaver, "SLEEP_TIMER", 5)
+      stub_const(ODK::ResponseSaver, "TEST_SLEEP_TIMER", 1)
     end
 
     it "should return a database serialization error", database_cleaner: :truncate do
@@ -56,7 +56,7 @@ describe ODK::ResponseSaver do
 
         thread2 = Thread.new do
           # wait until the first thread is sleepin
-          sleep(3)
+          sleep(0.5)
           insert_response_via_second_db_connection(checksum)
         end
 


### PR DESCRIPTION
Several changes:
* Return `:service_unavailable` instead of `:created` when there's a serialization issue, to allow the user to try again momentarily
  * Note: we're NOT yet destroying the original response because I couldn't get the specs to reproduce that behavior and I don't want to ship untestable code; we should see if these changes alone resolve the issue
* Increase MAX_TRIES by 20% in case it helps
* Add a random delay in between tries so that different requests can complete in different orders in case this can reduce the frequency of serialization conflicts
* Improve logging
* Add more specs