### PR TITLE
12238: Fix crash when trying to create a new form on DF servers

### DIFF
--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -29,6 +29,7 @@ module ActionLinks
     private
 
     def api_url(form)
+      return nil unless form.persisted? # Fixes a crash; this URL is meaningless for the 'new' route anyway.
       base_path = "#{h.request.base_url}#{h.current_root_path}#{OData::BASE_PATH}"
       responses_path = OData::FormDecorator.new(form).responses_url
       "#{base_path}/#{responses_path}"


### PR DESCRIPTION
Quick win for the servers that have the `NEMO_USE_DATA_FACTORY` env flag set. This helper is called on `forms/new` causing the crash, but only needed on `forms/show`.