### PR TITLE
12241 fix multilingual multilevel csv export in non-default language

### DIFF
--- a/app/models/results/csv/header_map.rb
+++ b/app/models/results/csv/header_map.rb
@@ -79,7 +79,8 @@ module Results
 
       def add_level_headers(code, level_names)
         JSON.parse(level_names).each do |level|
-          key = locales.detect { |l| level[l.to_s].present? } || level.keys.first
+          # Check every locale, starting with user preference, to see where the level has a real name defined.
+          key = ([I18n.locale] + locales).detect { |l| level[l.to_s].present? } || level.keys.first
           add(code, suffix: level[key.to_s])
         end
       end

--- a/spec/fixtures/response_csv/multilingual_cascading.csv
+++ b/spec/fixtures/response_csv/multilingual_cascading.csv
@@ -1,3 +1,3 @@
-ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,SelectOneQ1:Kingdom,SelectOneQ1:Species
+ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,SelectOneQ1:Royaume,SelectOneQ1:Espèce
 *id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,,0,,
-*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,Groupe,1,Animal,Chat
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,Groupe,1,Animale,Chat

--- a/spec/fixtures/response_csv/multilingual_cascading.csv
+++ b/spec/fixtures/response_csv/multilingual_cascading.csv
@@ -1,0 +1,3 @@
+ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,SelectOneQ1:Kingdom,SelectOneQ1:Species
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,,0,,
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,Groupe,1,Animal,Chat

--- a/spec/fixtures/response_csv/multilingual_cascading_en.csv
+++ b/spec/fixtures/response_csv/multilingual_cascading_en.csv
@@ -1,0 +1,3 @@
+ResponseID,Shortcode,Form,Submitter,DateSubmitted,Reviewed,GroupName,GroupLevel,SelectOneQ1:Kingdom,SelectOneQ1:Species
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,,0,,
+*id1*,*shortcode1*,Sample Form 1,A User 1,2015-11-20 06:30:00 -0600,false,Group 1,1,Animal,Cat

--- a/spec/models/results/csv/generator_spec.rb
+++ b/spec/models/results/csv/generator_spec.rb
@@ -341,6 +341,36 @@ describe Results::CSV::Generator, :reset_factory_sequences do
     end
   end
 
+  context "with multilingual cascading selects in non-default locale" do
+    let(:form) { create(:form, question_types: [{repeating: {items: ["multilevel_select_one"]}}]) }
+    let(:group) { form.c[0] }
+    let(:option_set) { form.c[0].c[0].option_set }
+    let(:option1) { option_set.c[0].option }
+    let(:option2) { option_set.c[0].c[0].option }
+
+    before do
+      # Avoid missing translation errors for headers. We're not testing those here as
+      # those are picked up with standard I18n.translate. In production this isn't an issue
+      # because fallbacks are enabled.
+      I18n.backend.store_translations(:fr, response: {csv_headers: I18n.t("response.csv_headers")})
+
+      get_mission.setting.update!(preferred_locales_str: "fr,en")
+      I18n.locale = :en # Non-default locale
+      group.update!(group_name_fr: "Groupe")
+      option_set.update!(level_names: [{en: "Kingdom", fr: "Royaume"}, {en: "Species", fr: "Espèce"}])
+      option1.update!(name_fr: "Animale")
+      option2.update!(name_fr: "Chat")
+
+      Timecop.freeze(submission_time) do
+        create_response(form: form, answer_values: [{repeating: [[[option1.name_en, option2.name_en]]]}])
+      end
+    end
+
+    it "uses french names when appropriate" do
+      is_expected.to match_user_facing_csv(prepare_response_csv_expectation("multilingual_cascading_en.csv"))
+    end
+  end
+
   context "with numeric values for select_one and select_multiple questions" do
     let(:form) { create(:form, question_types: %w[select_one select_multiple]) }
 

--- a/spec/models/results/csv/generator_spec.rb
+++ b/spec/models/results/csv/generator_spec.rb
@@ -314,8 +314,9 @@ describe Results::CSV::Generator, :reset_factory_sequences do
   context "with multilingual cascading selects" do
     let(:form) { create(:form, question_types: [{repeating: {items: ["multilevel_select_one"]}}]) }
     let(:group) { form.c[0] }
-    let(:option1) { form.c[0].c[0].option_set.c[0].option }
-    let(:option2) { form.c[0].c[0].option_set.c[0].c[0].option }
+    let(:option_set) { form.c[0].c[0].option_set }
+    let(:option1) { option_set.c[0].option }
+    let(:option2) { option_set.c[0].c[0].option }
 
     before do
       # Avoid missing translation errors for headers. We're not testing those here as
@@ -323,9 +324,11 @@ describe Results::CSV::Generator, :reset_factory_sequences do
       # because fallbacks are enabled.
       I18n.backend.store_translations(:fr, response: {csv_headers: I18n.t("response.csv_headers")})
 
-      get_mission.setting.update!(preferred_locales_str: "en,fr")
+      get_mission.setting.update!(preferred_locales_str: "fr,en")
       I18n.locale = :fr
       group.update!(group_name_fr: "Groupe")
+      option_set.update!(level_names: [{en: "Kingdom", fr: "Royaume"}, {en: "Species", fr: "Espèce"}])
+      option1.update!(name_fr: "Animale")
       option2.update!(name_fr: "Chat")
 
       Timecop.freeze(submission_time) do

--- a/spec/models/results/csv/generator_spec.rb
+++ b/spec/models/results/csv/generator_spec.rb
@@ -311,6 +311,33 @@ describe Results::CSV::Generator, :reset_factory_sequences do
     end
   end
 
+  context "with multilingual cascading selects" do
+    let(:form) { create(:form, question_types: [{repeating: {items: ["multilevel_select_one"]}}]) }
+    let(:group) { form.c[0] }
+    let(:option1) { form.c[0].c[0].option_set.c[0].option }
+    let(:option2) { form.c[0].c[0].option_set.c[0].c[0].option }
+
+    before do
+      # Avoid missing translation errors for headers. We're not testing those here as
+      # those are picked up with standard I18n.translate. In production this isn't an issue
+      # because fallbacks are enabled.
+      I18n.backend.store_translations(:fr, response: {csv_headers: I18n.t("response.csv_headers")})
+
+      get_mission.setting.update!(preferred_locales_str: "en,fr")
+      I18n.locale = :fr
+      group.update!(group_name_fr: "Groupe")
+      option2.update!(name_fr: "Chat")
+
+      Timecop.freeze(submission_time) do
+        create_response(form: form, answer_values: [{repeating: [[[option1.name_en, option2.name_en]]]}])
+      end
+    end
+
+    it "uses french names when appropriate" do
+      is_expected.to match_user_facing_csv(prepare_response_csv_expectation("multilingual_cascading.csv"))
+    end
+  end
+
   context "with numeric values for select_one and select_multiple questions" do
     let(:form) { create(:form, question_types: %w[select_one select_multiple]) }
 


### PR DESCRIPTION
This specific bug was only happening when the user's locale did not match the mission's default locale. Added a couple new specs for similar cases along with the fix.

Will include in this week's release (rather that hotfixing) after specs pass.