### PR TITLE
12389 export form ODK XML for easier Collect import

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -255,9 +255,8 @@ class FormsController < ApplicationController
   def zip_all(zipfile_path, forms)
     Zip::File.open(zipfile_path, Zip::File::CREATE) do |zipfile|
       forms.each do |form|
-        form_name = "form-#{form.name.dasherize}-#{Time.zone.today}.csv"
-        form_csv = Forms::Export.new(form).to_csv
-        zipfile.get_output_stream(form_name) { |f| f.write(form_csv) }
+        form_name = "form-#{form.name.dasherize}-#{Time.zone.today}.xml"
+        zipfile.get_output_stream(form_name) { |f| f.write(form.odk_xml.download) }
       rescue Zip::EntryExistsError => e
         Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "Form: #{form.id}"))
         notify_admins(e)

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -224,11 +224,18 @@ class FormsController < ApplicationController
     redirect_to(index_url_with_context)
   end
 
+  # Standard CSV export.
   def export
     exporter = Forms::Export.new(@form)
     send_data(exporter.to_csv, filename: "form-#{@form.name.dasherize}-#{Time.zone.today}.csv")
   end
 
+  # ODK XML export.
+  def export_xml
+    send_data(@form.odk_xml.download, filename: "form-#{@form.name.dasherize}-#{Time.zone.today}.xml")
+  end
+
+  # ODK XML export for all forms in mission/admin mode.
   def export_all
     forms = Form.where(mission: current_mission) # Mission could be nil for standard forms.
     forms = forms.published if current_mission.present?

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -235,7 +235,8 @@ class FormsController < ApplicationController
     send_data(@form.odk_xml.download, filename: "form-#{@form.name.dasherize}-#{Time.zone.today}.xml")
   end
 
-  # ODK XML export for all forms in mission/admin mode.
+  # ODK XML export for all published forms.
+  # Theoretically works for standard forms too, but they have no XML so can't be exported at this time.
   def export_all
     forms = Form.where(mission: current_mission) # Mission could be nil for standard forms.
     forms = forms.published if current_mission.present?

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -229,6 +229,16 @@ class FormsController < ApplicationController
     send_data(exporter.to_csv, filename: "form-#{@form.name.dasherize}-#{Time.zone.today}.csv")
   end
 
+  def export_all
+    forms = Form.where(mission: current_mission).published
+    zipfile_path = Rails.root.join("tmp/forms-#{current_mission.compact_name}-#{Time.zone.today}.zip")
+    zip_all(zipfile_path, forms)
+    send_file(zipfile_path)
+    # Use send_data (not send_file) in order to block until it's finished before deleting.
+    File.open(zipfile_path, "r") { |f| send_data(f.read, filename: File.basename(zipfile_path)) }
+    FileUtils.rm(zipfile_path)
+  end
+
   private
 
   # Decorates questions for choose_questions view.
@@ -237,6 +247,22 @@ class FormsController < ApplicationController
     # which doesn't work here because we're not paginating.
     @decorated_questions ||= # rubocop:disable Naming/MemoizedInstanceVariableName
       Draper::CollectionDecorator.decorate(@questions, with: QuestionDecorator)
+  end
+
+  # Given a set of forms, put them all in a zip file for download.
+  def zip_all(zipfile_path, forms)
+    Zip::File.open(zipfile_path, Zip::File::CREATE) do |zipfile|
+      forms.each do |form|
+        form_name = "form-#{form.name.dasherize}-#{Time.zone.today}.csv"
+        pp form_name
+        form_csv = Forms::Export.new(form).to_csv
+        zipfile.get_output_stream(form_name) { |f| f.write(form_csv) }
+      rescue Zip::EntryExistsError => e
+        Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: "Form: #{form.id}"))
+        notify_admins(e)
+        next
+      end
+    end
   end
 
   def setup_condition_computer

--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -5,8 +5,10 @@ module ActionLinks
   class FormLinkBuilder < LinkBuilder
     def initialize(form)
       actions = %i[show edit clone]
-      actions << [:export_csv, {url: h.export_form_path(form)}]
-      actions << [:export_xml, {url: h.export_xml_form_path(form)}]
+      unless new_action?
+        actions << [:export_csv, {url: h.export_form_path(form)}]
+        actions << [:export_xml, {url: h.export_xml_form_path(form)}] if form.odk_xml.attached?
+      end
 
       unless h.admin_mode?
         actions << [:go_live, {method: :patch}] unless form.live?

--- a/app/decorators/action_links/form_link_builder.rb
+++ b/app/decorators/action_links/form_link_builder.rb
@@ -4,7 +4,9 @@ module ActionLinks
   # Builds a list of action links for a form.
   class FormLinkBuilder < LinkBuilder
     def initialize(form)
-      actions = %i[show edit clone export]
+      actions = %i[show edit clone]
+      actions << [:export_csv, {url: h.export_form_path(form)}]
+      actions << [:export_xml, {url: h.export_xml_form_path(form)}]
 
       unless h.admin_mode?
         actions << [:go_live, {method: :patch}] unless form.live?

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -12,6 +12,10 @@ class ApplicationDecorator < Draper::Decorator
     "&nbsp;".html_safe # rubocop:disable Rails/OutputSafety
   end
 
+  def new_action?
+    %w[create new].include?(h.controller.action_name)
+  end
+
   def show_action?
     h.controller.action_name == "show"
   end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -6,7 +6,7 @@ module FormsHelper
     links = []
     links << create_link(Form) if can?(:create, Form)
     add_import_standard_link_if_appropriate(links)
-    links << link_to(t("action_links.models.form.export_all"), export_all_forms_path)
+    links << link_to(t("action_links.models.form.export_all"), export_all_forms_path) unless admin_mode?
     links << link_to(t("action_links.models.form.sms_console"), new_sms_test_path) if can?(:create, Sms::Test)
     links
   end

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -6,6 +6,7 @@ module FormsHelper
     links = []
     links << create_link(Form) if can?(:create, Form)
     add_import_standard_link_if_appropriate(links)
+    links << link_to(t("action_links.models.form.export_all"), export_all_forms_path)
     links << link_to(t("action_links.models.form.sms_console"), new_sms_test_path) if can?(:create, Sms::Test)
     links
   end

--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -9,6 +9,8 @@ module IconHelper
     drop_pin: "map-marker",
     edit: "pencil",
     export: "download",
+    export_csv: "download",
+    export_xml: "download",
     go_live: "play",
     import: "upload",
     index: "list",

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -923,6 +923,7 @@ en:
         new: "Create Form"
         sms_guide: "SMS Guide"
         sms_console: "SMS Test Console"
+        export_all: "Export All (Published)"
         go_live: "Go Live"
         pause: "Pause"
         return_to_draft: "Return to Draft Status"

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -923,7 +923,7 @@ en:
         new: "Create Form"
         sms_guide: "SMS Guide"
         sms_console: "SMS Test Console"
-        export_all: "Export All (Published)"
+        export_all: "Export XML"
         go_live: "Go Live"
         pause: "Pause"
         return_to_draft: "Return to Draft Status"

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -917,6 +917,7 @@ en:
     import_standard: "Import Standard"
     import_from_csv: "Import from CSV"
     export_csv: "Export CSV"
+    export_xml: "Export XML"
     export: "Export"
     models:
       form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,10 @@ ELMO::Application.routes.draw do
                                          mission_name: /[a-z][a-z0-9]*/ do
     # the rest of these routes can have admin mode or not
     resources :forms, constraints: ->(req) { req.format == :html } do
+      collection do
+        get "export_all"
+      end
+
       member do
         post "add-questions", as: "add_questions", action: "add_questions"
         put "clone"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,6 +137,7 @@ ELMO::Application.routes.draw do
         get "choose-questions", as: "choose_questions", action: "choose_questions"
         get "sms-guide", as: "sms_guide", action: "sms_guide"
         get "export"
+        get "export_xml"
       end
     end
 

--- a/spec/features/forms/form/form_export_spec.rb
+++ b/spec/features/forms/form/form_export_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "fileutils"
+require "zip"
+
+feature "form export" do
+  context "single form" do
+    let(:user) { create(:user, role_name: "coordinator") }
+    let(:form) { create(:form, :live, question_types: %w[text]) }
+
+    before do
+      login(user)
+      ODK::FormRenderJob.perform_now(form)
+    end
+
+    it "XML exports successfully" do
+      visit(form_path(form, locale: "en", mode: "m", mission_name: get_mission.compact_name))
+      click_link("Export XML")
+      expect(page.body).to match("<h:title>#{form.name}</h:title>")
+    end
+  end
+
+  context "multiple forms" do
+    let(:user) { create(:user, role_name: "coordinator") }
+    let(:form1) { create(:form, :live, question_types: %w[text]) }
+    let(:form2) { create(:form, :draft, question_types: %w[text]) } # Draft should not be exported
+    let(:form3) { create(:form, :paused, question_types: %w[text]) }
+
+    before do
+      login(user)
+      ODK::FormRenderJob.perform_now(form1)
+      ODK::FormRenderJob.perform_now(form3)
+    end
+
+    it "XML exports successfully" do
+      visit(forms_path(locale: "en", mode: "m", mission_name: get_mission.compact_name))
+      click_link("Export XML")
+
+      Zip::File.open_buffer(page.body) do |zipfile|
+        expect(zipfile.count).to be(2)
+        zipfile.each do |file|
+          expect(file.get_input_stream.read).to match("<h:title>.+</h:title>")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds 2 new links:
- export ODK XML for a particular form
- export ODK XML for all published forms (zip file)

Docs: https://getnemo.readthedocs.io/en/latest/content/export/xml.html