### PR TITLE
8634: Update hint text

### DIFF
--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -585,7 +585,7 @@ en:
         access_level: "Public: Any user can access the data via the API. Protected: Only specific users can access data via the API. Private: Nobody can access the data via the API."
         default_response_name: "Text entered here will be used as the default name of filled forms in ODK Collect. You can enter $QuestionCode to include the value of a question in the form.\n\nFor example, entering:\n\n&nbsp;&nbsp;&nbsp;Survey for $VillageNum-$Household\n\nmight name the form:\n\n&nbsp;&nbsp;&nbsp;Survey for 7-Smith\n\nassuming you have questions with codes 'VillageNum' and 'Household'\n\nYou can also enter an XPath calculate expression by wrapping it with <code>calc()</code>:\n\n&nbsp;&nbsp;&nbsp;<code>calc($VillageNum + 100 div 2)</code>"
       mission:
-        name: "A name for this Mission. Maximum 32 characters. Must be unique. Think about including the year if there will be future missions with the same name."
+        name: "A name for this Mission. Maximum 32 characters. Must be unique and only include letters, numbers, and spaces. Think about including the year if there will be future missions with the same name."
         locked: "If a mission is locked, Responses and Forms cannot be created or edited and Users cannot be added or deleted."
       option:
         name: "The textual description of this option that users will see."


### PR DESCRIPTION
Added hint text to specify only letters, numbers, and spaces. these appear to be the only validations

![image](https://user-images.githubusercontent.com/4603869/229911756-c555b8ab-d499-4dfc-b65d-51fb6d594604.png)


in `app/models/mission.rb`:
```
  validates :name, presence: true
  validates :name, format: {with: /\A[a-z][a-z0-9 ]*\z/i, message: :let_num_spc_only},
                   length: {minimum: 3, maximum: 32}, if: proc { |m| m.name.present? }
  validate :compact_name_unique
```