### PR TITLE
11469 uploader style

### DIFF
--- a/app/assets/stylesheets/local/forms/_file_upload.scss
+++ b/app/assets/stylesheets/local/forms/_file_upload.scss
@@ -36,31 +36,27 @@
   }
 }
 
-.dz-preview {
-  display: block;
-  height: 100px;
+// Custom styles for dropzone area
+.dz-preview-nemo {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 5px;
+  width: 100%;
   margin: 0;
-  width: inherit;
 
   &.dz-success .dz-progress .dz-upload {
     background: $darker-accent-color;
   }
 
   img {
-    display: block;
     float: left;
     height: 100px;
-    margin-right: 5px;
     width: 100px;
   }
 
   i.fa {
     font-size: 16px;
     margin-bottom: 5px;
-  }
-
-  .dz-details {
-    margin-left: 105px;
   }
 
   .dz-size {
@@ -71,15 +67,22 @@
     }
   }
 
-  .dz-progress {
-    background: $lighter-gray;
-    height: 5px;
-    width: 100%;
+  .dz-details {
+    flex-grow: 1;
+    display: flex;
+    flex-flow: column nowrap;
+    gap: 5px;
 
-    .dz-upload {
-      background: $darker-accent-color;
-      display: block;
+    .dz-progress {
+      background: $lighter-gray;
       height: 5px;
+      margin-bottom: 10px;
+  
+      .dz-upload {
+        background: $darker-accent-color;
+        display: block;
+        height: 1rem;
+      }
     }
   }
 

--- a/app/views/file_upload/_dropzone_preview.html.erb
+++ b/app/views/file_upload/_dropzone_preview.html.erb
@@ -4,6 +4,6 @@
     <div class="dz-filename"><span data-dz-name></span></div>
     <div class="dz-size" data-dz-size></div>
     <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div>
-    <%= link_to(content_tag(:i, "", class: 'fa fa-trash-o'), "#", data: { "dz-remove" => "" }) %>
+    <%= link_to(content_tag(:i, "", class: 'fa fa-trash-o'), "#", 'aria-label': 'Delete this file', data: { "dz-remove" => "" }) %>
   </div>
 </div>

--- a/app/views/file_upload/_dropzone_preview.html.erb
+++ b/app/views/file_upload/_dropzone_preview.html.erb
@@ -1,4 +1,4 @@
-<div class="dz-preview dz-file-preview">
+<div class="dz-preview-nemo dz-file-preview">
   <img data-dz-thumbnail />
   <div class="dz-details">
     <div class="dz-filename"><span data-dz-name></span></div>

--- a/spec/support/contexts/file_import.rb
+++ b/spec/support/contexts/file_import.rb
@@ -63,12 +63,12 @@ shared_context "file import" do
   end
 
   def expect_preview(node = page)
-    expect(node).to have_selector(".dz-preview")
+    expect(node).to have_selector(".dz-preview-nemo")
     expect(node).not_to have_content("The uploaded file was not an accepted format.")
   end
 
   def expect_no_preview(node = page)
-    expect(node).not_to have_selector(".dz-preview")
+    expect(node).not_to have_selector(".dz-preview-nemo")
   end
 
   def delete_file(node)


### PR DESCRIPTION
Restyles the upload progress bar area (using flexboxes):

![image](https://user-images.githubusercontent.com/4603869/231544699-e1ba38ac-414e-465c-9bb8-f4564a621f7c.png)

Wraps with flexbox for small screen sizes:

![image](https://user-images.githubusercontent.com/4603869/231546215-75ba9bda-b70e-4ee3-9bcd-3721e9184160.png)


BONUS!: Added an aria-label to the delete icon where there previously was no descriptive text

Additional issue: It is not possible to TAB to the dropzone box to upload a file using keyboard navigation. Setting the tabindex of the dropzone box to 0 is not sufficient as the triggers are on click and on drag, not on keydown. To fix this we would need to listen for keydown.