### PR TITLE
11090: Add error message for 500 internal server error

### DIFF
--- a/app/assets/javascripts/legacy/views/option_set_form.js
+++ b/app/assets/javascripts/legacy/views/option_set_form.js
@@ -287,6 +287,11 @@
             '.option_set_name',
             I18n.t('activerecord.errors.models.option_set.duplicate')
           );
+        } else if (jqxhr.status == 500) {
+          self.add_error(
+            '.option_set_options',
+            "This option is in use and cannot be deleted"
+          );
         } else {
           $('.elmo-form-wrapper').replaceWith('Server Error');
         }

--- a/app/assets/javascripts/legacy/views/option_set_form.js
+++ b/app/assets/javascripts/legacy/views/option_set_form.js
@@ -287,7 +287,7 @@
             '.option_set_name',
             I18n.t('activerecord.errors.models.option_set.duplicate')
           );
-        } else if (jqxhr.status == 500) {
+        } else if (jqxhr.status == 409) {
           self.add_error(
             '.option_set_options',
             I18n.t('activerecord.errors.models.option_set.cant_delete_option_in_use')

--- a/app/assets/javascripts/legacy/views/option_set_form.js
+++ b/app/assets/javascripts/legacy/views/option_set_form.js
@@ -290,7 +290,7 @@
         } else if (jqxhr.status == 500) {
           self.add_error(
             '.option_set_options',
-            "This option is in use and cannot be deleted"
+            I18n.t('activerecord.errors.models.option_set.cant_delete_option_in_use')
           );
         } else {
           $('.elmo-form-wrapper').replaceWith('Server Error');

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -136,9 +136,9 @@ class OptionSetsController < ApplicationController
     @option_set.save!
     raise StandardError if @option_set.errors?.attribute_names[0] == :name
   rescue ActiveRecord::DeleteRestrictionError
-    render(json: "error", status: :conflict)
+    create_or_update_error(:conflict)
   rescue StandardError
-    render(json: "error", status: :bad_request)
+    create_or_update_error(:bad_request)
   else
     create_or_update_success
   end
@@ -155,6 +155,10 @@ class OptionSetsController < ApplicationController
       # render where we should redirect
       render(json: option_sets_path.to_json)
     end
+  end
+
+  def create_or_update_error(err)
+    render(json: "error", status: err)
   end
 
   def generate_csv

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -133,16 +133,14 @@ class OptionSetsController < ApplicationController
 
   # creates/updates the option set
   def create_or_update
-    if @option_set.save
-      create_or_update_success
-    else
-      error = if @option_set.errors.attribute_names[0] == :name
-                :bad_request
-              else
-                :internal_server_error
-              end
-      render(json: "error", status: error)
-    end
+    @option_set.save
+    if @option_set.errors?.attribute_names[0] == :name then raise StandardError end
+  rescue ActiveRecord::DeleteRestrictionError
+    render(json: "error", status: :conflict)
+  rescue StandardError
+    render(json: "error", status: :bad_request)
+  else
+    create_or_update_success
   end
 
   def create_or_update_success

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -133,13 +133,11 @@ class OptionSetsController < ApplicationController
 
   # creates/updates the option set
   def create_or_update
-    @option_set.save!
+    @option_set.save! # the bang (!) raises exceptions for invalid saves
   rescue ActiveRecord::DeleteRestrictionError
-    create_or_update_error(:conflict)
+    create_or_update_error(:conflict) # when an in-use option is being deleted
   rescue StandardError
-    if @option_set.errors[:name].any?
-      create_or_update_error(:bad_request)
-    end
+    create_or_update_error(:bad_request) if @option_set.errors[:name].any? # when an option set name is taken
   else
     create_or_update_success
   end

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -134,11 +134,12 @@ class OptionSetsController < ApplicationController
   # creates/updates the option set
   def create_or_update
     @option_set.save!
-    raise StandardError if @option_set.errors?.attribute_names[0] == :name
   rescue ActiveRecord::DeleteRestrictionError
     create_or_update_error(:conflict)
   rescue StandardError
-    create_or_update_error(:bad_request)
+    if @option_set.errors[:name].any?
+      create_or_update_error(:bad_request)
+    end
   else
     create_or_update_success
   end

--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -133,8 +133,8 @@ class OptionSetsController < ApplicationController
 
   # creates/updates the option set
   def create_or_update
-    @option_set.save
-    if @option_set.errors?.attribute_names[0] == :name then raise StandardError end
+    @option_set.save!
+    raise StandardError if @option_set.errors?.attribute_names[0] == :name
   rescue ActiveRecord::DeleteRestrictionError
     render(json: "error", status: :conflict)
   rescue StandardError

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -721,6 +721,7 @@ en:
         must_be_group: "Parent must be a group."
         invalid_password: "Password must include at least one number, one lowercase letter, and one capital letter."
         all_required: "All fields are required."
+
       models:
         answer:
           required: "Please enter a value."
@@ -767,6 +768,7 @@ en:
           duplicate: "That option set name already exists in this mission, please enter a unique name."
           general: "There was a problem saving the option set."
           wrong_depth: "You have %{levels} option levels but your option tree is %{depth} options deep."
+          cant_delete_option_in_use: "You can't delete this option because it is in use."
         option_sets/import:
           general: "Option Set import is invalid (see below)."
           blank_interior_cell: "Error on row %{row_num}: blank interior cell."

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -721,7 +721,6 @@ en:
         must_be_group: "Parent must be a group."
         invalid_password: "Password must include at least one number, one lowercase letter, and one capital letter."
         all_required: "All fields are required."
-
       models:
         answer:
           required: "Please enter a value."


### PR DESCRIPTION
Issue: Trying to delete an option node that's in use shows a generic "Server Error" page with no details. 


I added in a check for error code 500, however, I'm not able to figure out how to filter specifically for `ActiveRecord::DeleteRestrictionError`. I think it is because this error comes from Rails but this code is catching errors from ajax, so the only info I can access is from that. Maybe there is a way to get more specific with it?

![image](https://github.com/thecartercenter/nemo/assets/4603869/a8cd806b-1403-40ac-8f38-2d361142b4df)
