### PR TITLE
Prevent dragging form items in cases related to skip rule targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ NOTES
 frpc.ini
 
 # IDE
+.vscode/*
 .idea/*
 !/.idea/runConfigurations/
 

--- a/app/assets/javascripts/views/form_items_draggable_list_view.js
+++ b/app/assets/javascripts/views/form_items_draggable_list_view.js
@@ -82,6 +82,7 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
   // would invalidate any conditions.
   // Returns false if invalid.
   check_condition_order(placeholder, item) {
+    
     // If item or any children refer to questions, the placeholder must be after all the referred questions.
     for (const c of Array.from(item.find('.refd-qing'))) {
       const refd = this.$(`li.form-item[data-id=${$(c).data('ref-id')}]`);
@@ -105,8 +106,9 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
   compare_ranks(a, b) {
     const ar = this.get_full_rank(a);
     const br = this.get_full_rank(b);
+    console.log("a rank " + ar + " " + "b rank " + br)
+
     for (let i = 0; i < ar.length; i++) {
-      const _ = ar[i];
       if (ar[i] > br[i]) {
         return 1;
       } else if (ar[i] < br[i]) {

--- a/app/assets/javascripts/views/form_items_draggable_list_view.js
+++ b/app/assets/javascripts/views/form_items_draggable_list_view.js
@@ -82,12 +82,12 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
   // would invalidate any conditions.
   // Returns false if invalid.
   check_condition_order(placeholder, item) {
-    console.log("check_condition_order called", placeholder, item)
+    //console.log("check_condition_order called", placeholder, item)
 
     // If item or any children refer to questions, the placeholder must be after all the referred questions.
     for (const c of Array.from(item.find('.refd-qing'))) {
       const refd = this.$(`li.form-item[data-id=${$(c).data('ref-id')}]`);
-      console.log("FIRST compare_ranks called", placeholder, refd)
+      //console.log("FIRST compare_ranks called", placeholder, refd)
 
       if (this.compare_ranks(placeholder, refd) !== 1) { 
         console.log("move denied")
@@ -95,6 +95,17 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
       }
     }
 
+    console.log(Array.from(item.find('.skip-rule-link')))
+    for (const c of Array.from(item.find('.skip-rule-link'))) {
+      const target = this.$(`li.form-item[data-id=${$(c).data('ref-id')}]`);
+      console.log("skip rule link for loop!", placeholder, target)
+
+      if (this.compare_ranks(placeholder, target) !== -1) { 
+        console.log("move denied")
+        return false;
+      }
+    }
+    
     // If item, or any children, are referred to by one or more questions,
     // the placeholder must be before all the referring questions.
     const child_ids = item.find('.form-item').andSelf().map(function () { return $(this).data('id'); });

--- a/app/assets/javascripts/views/form_items_draggable_list_view.js
+++ b/app/assets/javascripts/views/form_items_draggable_list_view.js
@@ -82,11 +82,17 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
   // would invalidate any conditions.
   // Returns false if invalid.
   check_condition_order(placeholder, item) {
-    
+    console.log("check_condition_order called", placeholder, item)
+
     // If item or any children refer to questions, the placeholder must be after all the referred questions.
     for (const c of Array.from(item.find('.refd-qing'))) {
       const refd = this.$(`li.form-item[data-id=${$(c).data('ref-id')}]`);
-      if (this.compare_ranks(placeholder, refd) !== 1) { return false; }
+      console.log("FIRST compare_ranks called", placeholder, refd)
+
+      if (this.compare_ranks(placeholder, refd) !== 1) { 
+        console.log("move denied")
+        return false;
+      }
     }
 
     // If item, or any children, are referred to by one or more questions,
@@ -94,11 +100,17 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
     const child_ids = item.find('.form-item').andSelf().map(function () { return $(this).data('id'); });
     for (const id of Array.from(child_ids.get())) {
       for (const refd_qing of Array.from(this.$(`.refd-qing[data-ref-id=${id}]`))) { // Loop over all matching refd_qings
-        const referrer = $(refd_qing.closest('li.form-item'));
-        if (this.compare_ranks(placeholder, referrer) !== -1) { return false; }
+        const referrer = $(refd_qing.closest('li.form-item')); 
+
+        console.log("SECOND compare_ranks called", placeholder, referrer)
+        if (this.compare_ranks(placeholder, referrer) !== -1) { 
+          console.log("move denied")
+          return false;
+        }
       }
     }
 
+    console.log("move allowed")
     return true;
   }
 
@@ -106,12 +118,14 @@ ELMO.Views.FormItemsDraggableListView = class FormItemsDraggableListView extends
   compare_ranks(a, b) {
     const ar = this.get_full_rank(a);
     const br = this.get_full_rank(b);
-    console.log("a rank " + ar + " " + "b rank " + br)
+    console.log("a rank ", ar,", b rank", br)
 
     for (let i = 0; i < ar.length; i++) {
       if (ar[i] > br[i]) {
+        console.log("compare_ranks RETURNING 1")
         return 1;
       } else if (ar[i] < br[i]) {
+        console.log("compare_ranks RETURNING -1")
         return -1;
       }
     }

--- a/app/decorators/questioning_decorator.rb
+++ b/app/decorators/questioning_decorator.rb
@@ -19,7 +19,7 @@ class QuestioningDecorator < FormItemDecorator
   def skip_rule_targets
     targets = skip_rules.map { |r| r.dest_item || :end }.uniq
     targets.sort_by! { |t| t == :end ? [1e9] : t.full_rank }
-    targets.map { |t| t == :end ? h.t("skip_rule.end") : "##{t.full_dotted_rank}" }
+    # targets.map { |t| t == :end ? h.t("skip_rule.end") : "##{t.full_dotted_rank}" }
   end
 
   def name_and_rank

--- a/app/views/questionings/_question.html.erb
+++ b/app/views/questionings/_question.html.erb
@@ -53,8 +53,16 @@
       <% if qing.skip_rules.any? %>
         <div class="skip-rule-links">
           <i class="fa fa-mail-forward"></i>
+              <% Rails.logger.debug("-----------------------------------")%>
+              <% Rails.logger.debug(qing.skip_rule_targets) %>
           <% qing.skip_rule_targets.each do |t| %>
-            <div class="skip-rule-link"><span><%= t %></span></div>
+            <div class="skip-rule-link" data-ref-id="<%= t.id %>">
+              <% Rails.logger.debug("-----------------------------------")%>
+              <% Rails.logger.debug(t.id) %>
+              <span>
+                <%= t == :end ? h.t("skip_rule.end") : "##{t.full_dotted_rank}" %>
+              </span>
+            </div>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Within the form editor: 

- If a question to be moved contains a skip rule, it now cannot be moved after its target (i.e, the question that will be skipped to)
- If the item is a skip rule target (i.e., it is a question that would be skipped to if certain conditions were true), it now cannot be moved before the question that refers to it.