### PR TITLE
12492: fix rendering to XML if there's a disabled cascading select questioning

### DIFF
--- a/app/decorators/odk/qing_group_decorator.rb
+++ b/app/decorators/odk/qing_group_decorator.rb
@@ -174,6 +174,8 @@ module ODK
     end
 
     def main_body_tags(xpath)
+      return +"" unless visible_children.present?
+
       # If this is a multilevel fragment, we are supposed to render just one of the subqings. %>
       if multilevel_fragment?
         visible_children[0].body_tags(group: self, xpath_prefix: xpath)


### PR DESCRIPTION
scenario:
- form has a cascading (multilevel) select that's disabled
- DelayedJob tries to render the form to XML automatically

result:
- `undefined method 'body_tags' for nil:NilClass`

fix:
- don't attempt to render non-existent child

note that BOTH the `if` and `else` eventually attempt to use `visible_children[0]`, but they only currently check if there are `children` and not whether the children are visible. this code logic is extremely complex and branching, but the fix here is likely safe.

tested and verified using the prod form linked from the redmine issue (screenshots not uploaded for privacy reasons).