### PR TITLE
12494: add new 'meta' section to ODK XML

### DIFF
--- a/app/decorators/odk/form_decorator.rb
+++ b/app/decorators/odk/form_decorator.rb
@@ -9,11 +9,10 @@ module ODK
     IR_QUESTION = "ir01"
     IR_CODE = "ir02"
 
-    def default_response_name_instance_tag
-      if default_response_name.present?
-        content_tag(:meta, tag(:instanceName))
-      else
-        ""
+    def meta_tags
+      content_tag("orx:meta") do
+        h.concat(tag("orx:instanceID"))
+        h.concat(tag("orx:instanceName")) if default_response_name.present?
       end
     end
 

--- a/app/views/forms/odk/_instances.xml.erb
+++ b/app/views/forms/odk/_instances.xml.erb
@@ -1,6 +1,5 @@
 <instance>
   <%= content_tag(:data, id: @form.id, version: @form.number) do %>
-    <%= @form.default_response_name_instance_tag %>
     <%= render("forms/odk/instance_node", node: @form.root_group) %>
 
     <%# Incomplete response question nodes %>
@@ -9,9 +8,7 @@
       <%= tag(ODK::FormDecorator::IR_CODE) %>
     <% end %>
 
-    <orx:meta>
-      <orx:instanceID/>
-    </orx:meta>
+    <%= @form.meta_tags %>
   <% end %>
 </instance>
 

--- a/app/views/forms/odk/_instances.xml.erb
+++ b/app/views/forms/odk/_instances.xml.erb
@@ -8,6 +8,10 @@
       <%= tag(ODK::FormDecorator::IR_QUESTION) %>
       <%= tag(ODK::FormDecorator::IR_CODE) %>
     <% end %>
+
+    <orx:meta>
+      <orx:instanceID/>
+    </orx:meta>
   <% end %>
 </instance>
 

--- a/app/views/forms/show.xml.erb
+++ b/app/views/forms/show.xml.erb
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:ev="http://www.w3.org/2001/xml-events"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:jr="http://openrosa.org/javarosa"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:orx="https://openrosa.org/xforms"
+>
   <h:head>
     <h:title><%= @form.full_name %></h:title>
     <model>

--- a/spec/fixtures/odk/forms/allows_incomplete.xml
+++ b/spec/fixtures/odk/forms/allows_incomplete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -8,6 +8,9 @@
           <*itemcode1*/>
           <ir01/>
           <ir02/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/bilingual.xml
+++ b/spec/fixtures/odk/forms/bilingual.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>Sample Form 1</h:title>
     <model>
       <instance>
         <data id="*form1*" version="*formver1*">
           <*itemcode1*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/conditional_logic.xml
+++ b/spec/fixtures/odk/forms/conditional_logic.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -17,6 +17,9 @@
           <*itemcode9*/>
           <*itemcode10*/>
           <*itemcode11*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode2*_level2">

--- a/spec/fixtures/odk/forms/default_patterns.xml
+++ b/spec/fixtures/odk/forms/default_patterns.xml
@@ -5,9 +5,6 @@
     <model>
       <instance>
         <data id="*form1*" version="*formver1*">
-          <meta>
-            <instanceName/>
-          </meta>
           <*itemcode1*>
             <header/>
             <*itemcode2*/>
@@ -19,6 +16,7 @@
           <*itemcode6*/>
           <orx:meta>
             <orx:instanceID/>
+            <orx:instanceName/>
           </orx:meta>
         </data>
       </instance>

--- a/spec/fixtures/odk/forms/default_patterns.xml
+++ b/spec/fixtures/odk/forms/default_patterns.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -17,6 +17,9 @@
             <*itemcode5*_2/>
           </*itemcode1*>
           <*itemcode6*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode2*_level2">

--- a/spec/fixtures/odk/forms/dynamic_values.xml
+++ b/spec/fixtures/odk/forms/dynamic_values.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>Dynamic answers for option sets</h:title>
     <model>
@@ -11,6 +11,9 @@
             <*itemcode3*/>
             <*itemcode4*/>
           </*itemcode2*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode1*_numeric_values">

--- a/spec/fixtures/odk/forms/empty_and_disabled.xml
+++ b/spec/fixtures/odk/forms/empty_and_disabled.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -16,6 +16,9 @@
           <*itemcode6* jr:template="">
             <header/>
           </*itemcode6*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/empty_and_hidden.xml
+++ b/spec/fixtures/odk/forms/empty_and_hidden.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -22,6 +22,9 @@
             <header/>
             <*itemcode9*/>
           </*itemcode8*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/grid_group_with_condition.xml
+++ b/spec/fixtures/odk/forms/grid_group_with_condition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -13,6 +13,9 @@
             <*itemcode4*/>
           </*itemcode2*>
           <*itemcode5*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/media_prompts.xml
+++ b/spec/fixtures/odk/forms/media_prompts.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -8,6 +8,9 @@
           <*itemcode1*/>
           <*itemcode2*/>
           <*itemcode3*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/media_questions.xml
+++ b/spec/fixtures/odk/forms/media_questions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -12,6 +12,9 @@
           <*itemcode5*/>
           <*itemcode6*/>
           <*itemcode7*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/multi_screen_gridable.xml
+++ b/spec/fixtures/odk/forms/multi_screen_gridable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -10,6 +10,9 @@
             <*itemcode2*/>
             <*itemcode3*/>
           </*itemcode1*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/multi_screen_group.xml
+++ b/spec/fixtures/odk/forms/multi_screen_group.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -11,6 +11,9 @@
             <*itemcode3*/>
             <*itemcode4*/>
           </*itemcode1*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/multiscreen_group_with_multilevel.xml
+++ b/spec/fixtures/odk/forms/multiscreen_group_with_multilevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -13,6 +13,9 @@
             <*itemcode4*_2/>
             <*itemcode5*/>
           </*itemcode1*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode1*_level2">

--- a/spec/fixtures/odk/forms/nested_group_with_multilevel.xml
+++ b/spec/fixtures/odk/forms/nested_group_with_multilevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -17,6 +17,9 @@
             </*itemcode4*>
             <*itemcode7*/>
           </*itemcode1*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode1*_level2">

--- a/spec/fixtures/odk/forms/nested_repeat_group.xml
+++ b/spec/fixtures/odk/forms/nested_repeat_group.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -26,6 +26,9 @@
             <*itemcode12*/>
             <*itemcode13*/>
           </*itemcode9*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/non_repeat_group_with_condition.xml
+++ b/spec/fixtures/odk/forms/non_repeat_group_with_condition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -12,6 +12,9 @@
             <*itemcode4*/>
             <*itemcode5*/>
           </*itemcode2*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/non_repeat_group_with_multilevel_select.xml
+++ b/spec/fixtures/odk/forms/non_repeat_group_with_multilevel_select.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -13,6 +13,9 @@
             <*itemcode4*_2/>
             <*itemcode5*/>
           </*itemcode1*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode1*_level2">

--- a/spec/fixtures/odk/forms/preload_last_saved.xml
+++ b/spec/fixtures/odk/forms/preload_last_saved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -8,6 +8,9 @@
           <*itemcode1*/>
           <*itemcode2*/>
           <*itemcode3*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="last-saved" src="jr://instance/last-saved"/>

--- a/spec/fixtures/odk/forms/repeat_group.xml
+++ b/spec/fixtures/odk/forms/repeat_group.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -21,6 +21,9 @@
             <*itemcode9*/>
             <*itemcode10*/>
           </*itemcode8*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/repeat_group_count.xml
+++ b/spec/fixtures/odk/forms/repeat_group_count.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -22,6 +22,9 @@
             <*itemcode10*/>
             <*itemcode11*/>
           </*itemcode9*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/repeat_group_count_nested.xml
+++ b/spec/fixtures/odk/forms/repeat_group_count_nested.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -25,6 +25,9 @@
             <*itemcode11*/>
             <*itemcode12*/>
           </*itemcode10*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/single_screen_repeat_group_with_condition.xml
+++ b/spec/fixtures/odk/forms/single_screen_repeat_group_with_condition.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -11,6 +11,9 @@
             <*itemcode3*/>
             <*itemcode4*/>
           </*itemcode1*>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <itext>

--- a/spec/fixtures/odk/forms/small_large_multilevel.xml
+++ b/spec/fixtures/odk/forms/small_large_multilevel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -10,6 +10,9 @@
           <*itemcode2*_1/>
           <*itemcode2*_2/>
           <*itemcode2*_3/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode1*_level2">

--- a/spec/fixtures/odk/forms/standard_copy_with_xpath.xml
+++ b/spec/fixtures/odk/forms/standard_copy_with_xpath.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>Dynamic answers for option sets</h:title>
     <model>
@@ -7,6 +7,9 @@
         <data id="*form1*" version="*formver1*">
           <*itemcode1*/>
           <*itemcode2*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode1*_numeric_values">

--- a/spec/fixtures/odk/forms/various_question_types.xml
+++ b/spec/fixtures/odk/forms/various_question_types.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -22,6 +22,9 @@
           <*itemcode14*/>
           <*itemcode15*/>
           <*itemcode16*/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode2*_level2">

--- a/spec/fixtures/odk/forms/various_selects.xml
+++ b/spec/fixtures/odk/forms/various_selects.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:orx="https://openrosa.org/xforms">
   <h:head>
     <h:title>*formname1*</h:title>
     <model>
@@ -11,6 +11,9 @@
           <*itemcode3*_1/>
           <*itemcode3*_2/>
           <*itemcode3*_3/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
         </data>
       </instance>
       <instance id="*optsetcode2*_level2">


### PR DESCRIPTION
to fix ODK Central importing:

![Screen Shot 2023-10-18 at 16 40 12](https://github.com/thecartercenter/nemo/assets/2047062/082af2f0-74a9-4e49-a270-06acada69eec)

tested and verified working after this change.

per the [ODK XForms docs](https://getodk.github.io/xforms-spec/#metadata), this section was missing:

 ```diff
<model>
   <instance>
       <data id="asdf" orx:version="123">
           <question1/>
           <question2/>
+          <orx:meta>
+            <orx:instanceID/>
+          </orx:meta>
       </data>
   </instance>
 </model>
```

note: other meta options include `timeStart`/`timeEnd` (automatic timestamps when the form entry was started/ended), `deviceID`, etc. if we wish to use them in the future.