### PR TITLE
12506: discard jobs on ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
+# https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html
 class ApplicationJob < ActiveJob::Base
   include Rails.application.routes.url_helpers
 
   around_perform do |_job, block|
     Setting.with_cache(&block)
+  end
+
+  # Skip the job if the subject of the job has already been destroyed.
+  discard_on ActiveJob::DeserializationError do |job, error|
+    Rails.logger.error("Skipping #{job.class}: #{error.message}")
+    Sentry.add_breadcrumb(Sentry::Breadcrumb.new(message: error.message))
+    Sentry.capture_message("#{job.class} DeserializationError")
   end
 end


### PR DESCRIPTION
if, for example, a form (or other object) is created and then deleted before its associated background job can run, the background job will loudly fail with a server alert and possibly cause the DJ queue to backup until it's manually deleted.

instead, we should skip the job if its target no longer exists. tested and verified locally with a series of different fail cases.

the event is also logged to Sentry for analytics.