### PR TITLE
12511: loudly fail if there are no Option Set CSV headers available

### DIFF
--- a/app/controllers/option_sets_controller.rb
+++ b/app/controllers/option_sets_controller.rb
@@ -58,6 +58,9 @@ class OptionSetsController < ApplicationController
 
   def export
     send_data(generate_csv, filename: "#{@option_set.name}.csv")
+  rescue MissingTranslationError
+    flash[:error] = t("activerecord.errors.models.option.missing_level_translation", locale_name: I18n.locale)
+    redirect_to(request.referer) # Reload page.
   end
 
   # always via AJAX

--- a/app/models/missing_translation_error.rb
+++ b/app/models/missing_translation_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Error when translations are missing.
+class MissingTranslationError < StandardError
+end

--- a/app/models/option_set.rb
+++ b/app/models/option_set.rb
@@ -242,7 +242,9 @@ class OptionSet < ApplicationRecord
 
       if multilevel?
         # use the level names as column headings for a multi-level option set
-        headers.concat(levels.map(&:name))
+        names = levels.map(&:name)
+        raise MissingTranslationError if names.any?(&:blank?)
+        headers.concat(names)
       else
         # the human-readable name for the Option.name attribute otherwise (e.g. "Name")
         headers << Option.human_attribute_name(:name)

--- a/config/locales/en/main.yml
+++ b/config/locales/en/main.yml
@@ -758,6 +758,7 @@ en:
         option:
           cant_delete_if_has_response: "You can't delete this Option because it is included in at least one Response."
           names_cant_be_all_blank: "At least one name translation must be given for each option."
+          missing_level_translation: "Missing default '%{locale_name}' translation for option level names."
           names_too_long: "Names must be at most 30 characters in length."
           invalid_coordinates: "The provided coordinates are not valid."
         option_set:


### PR DESCRIPTION
Option Set CSV export is silently broken if translations don't exist; loudly fail if there are no OS CSV headers available