### PR TITLE
12527: Add translations to XLSForm export

### DIFF
--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -70,7 +70,8 @@ module Forms
 
       # translation columns
       locales.each do |locale|
-        questions.row(0).push("label::#{language_name(locale)} (#{locale.to_s})", "hint::#{language_name(locale)} (#{locale.to_s})")
+        questions.row(0).push("label::#{language_name(locale)} (#{locale})",
+          "hint::#{language_name(locale)} (#{locale})")
       end
 
       questions.row(0).push("name", "required", "relevant", "constraint", "choice_filter")
@@ -120,9 +121,10 @@ module Forms
             questions.row(row_index).push("begin group")
           end
 
-           # write translated label and hint columns
+          # write translated label and hint columns
           locales.each do |locale|
-            questions.row(row_index).push(q.group_name_translations[locale.to_s], q.group_hint_translations[locale.to_s])
+            questions.row(row_index).push(q.group_name_translations[locale.to_s],
+              q.group_hint_translations[locale.to_s])
           end
 
           # write group name
@@ -184,7 +186,8 @@ module Forms
 
                 # write translated label and hint columns
                 locales.each do |locale|
-                  questions.row(row_index + l_index).push(q.question.name_translations[locale.to_s], q.question.hint_translations[locale.to_s])
+                  questions.row(row_index + l_index).push(q.question.name_translations[locale.to_s],
+                    q.question.hint_translations[locale.to_s])
                 end
 
                 questions.row(row_index + l_index).push(name_to_push,
@@ -204,7 +207,8 @@ module Forms
               questions.row(row_index).push(type_to_push)
               # write translated label and hint columns
               locales.each do |locale|
-                questions.row(row_index).push(q.question.name_translations[locale.to_s], q.question.hint_translations[locale.to_s])
+                questions.row(row_index).push(q.question.name_translations[locale.to_s],
+                  q.question.hint_translations[locale.to_s])
               end
               questions.row(row_index).push(q.code, q.required.to_s,
                 conditions_to_push, constraints_to_push, choice_filter)
@@ -356,7 +360,7 @@ module Forms
       header_row = []
       header_row.push("list_name", "name")
       locales.each do |locale|
-        header_row.push("label::#{language_name(locale)} (#{locale.to_s})")
+        header_row.push("label::#{language_name(locale)} (#{locale})")
       end
 
       column_counter = 0
@@ -383,7 +387,7 @@ module Forms
               column_counter.times { level_to_push.push("") }
 
               # Obtain array of all ancestor nodes (except for the root, which is nameless)
-              level_to_push += vanillify(node.ancestors[1..].map(&:name)) # VANILLIFY THIS
+              level_to_push += vanillify(node.ancestors[1..].map(&:name))
             end
           else
             listname_to_push = os.name
@@ -430,10 +434,10 @@ module Forms
     def vanillify(input)
       # remove extra characters and replace spaces with underscores
       # for XLSForm compatibility
-      if input.class == String
-        out = input.vanilla.tr(" ", "_")
-      elsif input.class == Array
-        out = input.map { |n| n.vanilla.tr(" ", "_") }
+      if input.instance_of?(String)
+        input.vanilla.tr(" ", "_")
+      elsif input.instance_of?(Array)
+        input.map { |n| n.vanilla.tr(" ", "_") }
       else
         raise "Unallowed type passed to vanillify: #{input.class}"
       end

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/MethodLength
 module Forms
   # Exports a form to a human readable format for science!
-  class Export
+  class Export # rubocop:disable Metrics/ClassLength
     include LanguageHelper
 
     COLUMNS = %w[
@@ -53,7 +54,7 @@ module Forms
       end
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Style/Next
+    # rubocop:disable Metrics/BlockLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Style/Next
     def to_xls
       book = Spreadsheet::Workbook.new
 
@@ -176,11 +177,6 @@ module Forms
                 # Modify question name
                 name_to_push = "#{q.code}_#{level_name}"
 
-                # Modify question label
-                # NOTE: the question "label" (what NEMO calls "name") will have to be manually edited
-                # in the exported XLSForm by the user so that it makes grammatical sense.
-                label_to_push = "#{q.name}_#{level_name}"
-
                 # push a row for each level
                 questions.row(row_index + l_index).push(type_to_push)
 
@@ -218,7 +214,8 @@ module Forms
             questions.row(row_index).push(qtype_converted)
             # write translated label and hint columns
             locales.each do |locale|
-              questions.row(row_index).push(q.question.name_translations[locale.to_s], q.question.hint_translations[locale.to_s])
+              questions.row(row_index).push(q.question.name_translations[locale.to_s],
+                q.question.hint_translations[locale.to_s])
             end
             questions.row(row_index).push(q.code, q.required.to_s,
               conditions_to_push, constraints_to_push, choice_filter)
@@ -248,7 +245,8 @@ module Forms
             row_index += 1
           end
         end
-      end # end of form loop
+      end
+      # end of giant @form loop
 
       ## Choices
       # return an array of option set data to write to the spreadsheet
@@ -276,7 +274,7 @@ module Forms
       book.write(file)
       file.string
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Style/Next
+    # rubocop:enable Metrics/BlockLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Style/Next
 
     private
 
@@ -414,7 +412,7 @@ module Forms
 
         # prep header row
         # omit last entry (lowest level)
-        unless os.level_names.blank?
+        if os.level_names.present?
           os.level_names[0..-2].each do |level|
             header_row.push(vanillify(level.values[0]))
 
@@ -444,3 +442,4 @@ module Forms
     end
   end
 end
+# rubocop:enable Metrics/MethodLength

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -303,7 +303,8 @@ module Forms
         # node = the current option node
         os.option_nodes.each do |node|
           level_to_push = [] # array to be filled with parent levels if needed
-          listname_to_push = ""
+          listname_to_push = "" # name of the option set
+
           if node.level.present?
             # per XLSform style, option sets with levels need to have the
             # list_name replaced with the level name to distinguish each row.
@@ -323,7 +324,11 @@ module Forms
 
           if node.option.present? # rubocop:disable Style/Next
             option_row = []
-            option_row.push(listname_to_push, node.option.canonical_name, node.option.canonical_name)
+
+            # remove extra chars and spaces from choice name
+            choicename_to_push = vanillify(node.option.canonical_name)
+
+            option_row.push(listname_to_push, choicename_to_push, choicename_to_push)
             option_row += level_to_push # append levels, if any, to rightmost columns
             os_matrix.push(option_row)
           end

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -124,8 +124,8 @@ module Forms
 
           # write translated label and hint columns
           locales.each do |locale|
-            questions.row(row_index).push(q.group_name_translations[locale.to_s],
-              q.group_hint_translations[locale.to_s])
+            questions.row(row_index).push(q.group_name_translations&.dig(locale.to_s),
+              q.group_hint_translations&.dig(locale.to_s))
           end
 
           # write group name
@@ -182,8 +182,8 @@ module Forms
 
                 # write translated label and hint columns
                 locales.each do |locale|
-                  questions.row(row_index + l_index).push(q.question.name_translations[locale.to_s],
-                    q.question.hint_translations[locale.to_s])
+                  questions.row(row_index + l_index).push(q.question.name_translations&.dig(locale.to_s),
+                    q.question.hint_translations&.dig(locale.to_s))
                 end
 
                 questions.row(row_index + l_index).push(name_to_push,
@@ -203,8 +203,8 @@ module Forms
               questions.row(row_index).push(type_to_push)
               # write translated label and hint columns
               locales.each do |locale|
-                questions.row(row_index).push(q.question.name_translations[locale.to_s],
-                  q.question.hint_translations[locale.to_s])
+                questions.row(row_index).push(q.question.name_translations&.dig(locale.to_s),
+                  q.question.hint_translations&.dig(locale.to_s))
               end
               questions.row(row_index).push(q.code, q.required.to_s,
                 conditions_to_push, constraints_to_push, choice_filter)
@@ -214,8 +214,8 @@ module Forms
             questions.row(row_index).push(qtype_converted)
             # write translated label and hint columns
             locales.each do |locale|
-              questions.row(row_index).push(q.question.name_translations[locale.to_s],
-                q.question.hint_translations[locale.to_s])
+              questions.row(row_index).push(q.question.name_translations&.dig(locale.to_s),
+                q.question.hint_translations&.dig(locale.to_s))
             end
             questions.row(row_index).push(q.code, q.required.to_s,
               conditions_to_push, constraints_to_push, choice_filter)
@@ -402,7 +402,7 @@ module Forms
 
             # push translated label columns
             locales.each do |locale|
-              option_row.push(node.option.name_translations[locale.to_s])
+              option_row.push(node.option.name_translations&.dig(locale.to_s))
             end
 
             option_row += level_to_push # append levels, if any, to rightmost columns
@@ -429,9 +429,11 @@ module Forms
       os_matrix.insert(0, header_row)
     end
 
+    # recursively remove pesky characters and replace spaces with underscores
+    # for XLSForm compatibility
     def vanillify(input)
-      # remove extra characters and replace spaces with underscores
-      # for XLSForm compatibility
+      return "" if input.nil?
+
       if input.instance_of?(String)
         input.vanilla.tr(" ", "_")
       elsif input.instance_of?(Array)

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -3,6 +3,8 @@
 module Forms
   # Exports a form to a human readable format for science!
   class Export
+    include LanguageHelper
+
     COLUMNS = %w[
       Level Type Code Prompt Required? Repeatable? SkipLogic Constraints
       DisplayLogic DisplayConditions Default Hidden
@@ -60,9 +62,17 @@ module Forms
       choices = book.create_worksheet(name: "choices")
       settings = book.create_worksheet(name: "settings")
 
+      # Get languages
+      locales = @form.mission.setting.preferred_locales
+
       # Write sheet headings at row index 0
       questions.row(0).push("type", "name", "label", "required", "relevant", "constraint", "choice_filter")
       settings.row(0).push("form_title", "form_id", "version", "default_language")
+
+      # write translation column(s) to header row
+      locales.each do |locale|
+        questions.row(0).push("label::#{language_name(locale)}")
+      end
 
       group_depth = 1 # assume base level
       repeat_depth = 1
@@ -183,6 +193,10 @@ module Forms
             questions.row(row_index).push(qtype_converted, q.code, q.name, q.required.to_s,
               conditions_to_push, constraints_to_push, choice_filter)
           end
+
+          # do we have translations?
+
+          # write translated label::language (xx) columns
         end
       end
 


### PR DESCRIPTION
- The exported XLSForm will now include label columns for all languages specified in the form's mission
- Blank cells will be written when a translation is missing
- Bonus: fixes "end group" and "repeat group" lines not being written if they are at the very end of the form

Example of exported XLSForm imported into ODK Central:
https://github.com/thecartercenter/nemo/assets/4603869/2dace73d-b672-4a7a-b043-ca9b8eb082fc

