### PR TITLE
12614: XLSForm export: Add default value, repeat count, and media prompt columns

### DIFF
--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -176,6 +176,8 @@ module Forms
           constraint_msg_to_push = Array.new(locales.length, [])
 
           # obtain default response values, or else an empty string
+          # if preload last saved value is checked, indicate this using XLSForm format
+          # https://docs.getodk.org/form-logic/#values-from-the-last-saved-record
           if q.preload_last_saved
             default_to_push = "${last-saved##{q.code}}"
           else

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -77,14 +77,8 @@ module Forms
       locales = @form.mission.setting.preferred_locales
 
       # Write sheet headings at row index 0
-      questions.row(0).push("type")
-
-      locales.each do |locale|
-        questions.row(0).push("label::#{language_name(locale)} (#{locale})",
-          "hint::#{language_name(locale)} (#{locale})")
-      end
-
       questions.row(0).push(
+        "type", *local_headers("label", locales), *local_headers("hint", locales),
         "name", "required", "repeat_count", "appearance", "relevant", "default", "choice_filter",
         "constraint", *local_headers("constraint_message", locales),
         *local_headers("image", locales), *local_headers("audio", locales), *local_headers("video", locales)
@@ -147,10 +141,14 @@ module Forms
             repeat_count_to_push = ""
           end
 
-          # write translated label and hint columns
+          # write translated labels
           locales.each do |locale|
-            questions.row(row_index).push(q.group_name_translations&.dig(locale.to_s),
-              q.group_hint_translations&.dig(locale.to_s))
+            questions.row(row_index).push(q.group_name_translations&.dig(locale.to_s))
+          end
+
+          # write translated hints
+          locales.each do |locale| # rubocop:disable Style/CombinableLoops
+            questions.row(row_index).push(q.group_hint_translations&.dig(locale.to_s))
           end
 
           # write group name
@@ -251,10 +249,14 @@ module Forms
                 # push a row for each level
                 questions.row(row_index + l_index).push(type_to_push)
 
-                # write translated label and hint columns
+                # write translated labels
                 locales.each do |locale|
-                  questions.row(row_index + l_index).push(q.question.name_translations&.dig(locale.to_s),
-                    q.question.hint_translations&.dig(locale.to_s))
+                  questions.row(row_index + l_index).push(q.question.name_translations&.dig(locale.to_s))
+                end
+
+                # write translated hints
+                locales.each do |locale| # rubocop:disable Style/CombinableLoops
+                  questions.row(row_index + l_index).push(q.question.hint_translations&.dig(locale.to_s))
                 end
 
                 questions.row(row_index + l_index).push(name_to_push,
@@ -272,10 +274,15 @@ module Forms
 
               # Write the question row
               questions.row(row_index).push(type_to_push)
-              # write translated label and hint columns
+
+              # write translated labels
               locales.each do |locale|
-                questions.row(row_index).push(q.question.name_translations&.dig(locale.to_s),
-                  q.question.hint_translations&.dig(locale.to_s))
+                questions.row(row_index).push(q.question.name_translations&.dig(locale.to_s))
+              end
+
+              # write translated hints
+              locales.each do |locale| # rubocop:disable Style/CombinableLoops
+                questions.row(row_index).push(q.question.hint_translations&.dig(locale.to_s))
               end
 
               questions.row(row_index).push(q.code, q.required.to_s, repeat_count_to_push, appearance_to_push,
@@ -284,10 +291,15 @@ module Forms
           else # no option set present
             # Write the question row as normal
             questions.row(row_index).push(qtype_converted)
-            # write translated label and hint columns
+
+            # write translated labels
             locales.each do |locale|
-              questions.row(row_index).push(q.question.name_translations&.dig(locale.to_s),
-                q.question.hint_translations&.dig(locale.to_s))
+              questions.row(row_index).push(q.question.name_translations&.dig(locale.to_s))
+            end
+
+            # write translated hints
+            locales.each do |locale| # rubocop:disable Style/CombinableLoops
+              questions.row(row_index).push(q.question.hint_translations&.dig(locale.to_s))
             end
 
             questions.row(row_index).push(q.code, q.required.to_s, repeat_count_to_push, appearance_to_push,

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -90,6 +90,9 @@ module Forms
         questions.row(0).push("constraint message::#{language_name(locale)} (#{locale})")
       end
 
+      # Media prompts
+      questions.row(0).push("image", "audio", "video")
+
       # array for tracking nested groups.
       # push :group when a regular group is encountered, :repeat if repeat group.
       # when a group ends, we check .last, write "end group" or "end repeat" ,and then pop the last item out.
@@ -175,6 +178,19 @@ module Forms
           # obtain default response values, or else an empty string
           default_to_push = q.default || ""
 
+          # obtain media prompt content type and filename, if any
+          # column order = image, audio, video
+          # uploaded media will be one of these types; the other columns should be filled with an empty string
+          media_prompt_to_push = Array.new(3, "")
+          case q.media_prompt.content_type&.split("/")&.first || ""
+          when "image"
+            media_prompt_to_push[0] = q.media_prompt.filename.to_s
+          when "audio"
+            media_prompt_to_push[1] = q.media_prompt.filename.to_s
+          when "video"
+            media_prompt_to_push[2] = q.media_prompt.filename.to_s
+          end
+
           # this is not a (repeat) group, so repeat_count is unused
           repeat_count_to_push = ""
 
@@ -232,7 +248,7 @@ module Forms
                 end
 
                 questions.row(row_index + l_index).push(name_to_push,
-                  q.required.to_s, repeat_count_to_push, appearance_to_push, conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
+                  q.required.to_s, repeat_count_to_push, appearance_to_push, conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push, *media_prompt_to_push)
 
                 # define the choice_filter cell for the following row, e.g, "state=${selected_state}"
                 choice_filter = "#{level_name}=${#{name_to_push}}"
@@ -253,7 +269,7 @@ module Forms
               end
 
               questions.row(row_index).push(q.code, q.required.to_s, repeat_count_to_push, appearance_to_push,
-                conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
+                conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push, *media_prompt_to_push)
             end
           else # no option set present
             # Write the question row as normal
@@ -265,7 +281,7 @@ module Forms
             end
 
             questions.row(row_index).push(q.code, q.required.to_s, repeat_count_to_push, appearance_to_push,
-              conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
+              conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push, *media_prompt_to_push)
           end
         end
 

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -84,7 +84,7 @@ module Forms
           "hint::#{language_name(locale)} (#{locale})")
       end
 
-      questions.row(0).push("name", "required", "appearance", "relevant", "choice_filter", "constraint")
+      questions.row(0).push("name", "required", "appearance", "relevant", "default", "choice_filter", "constraint")
 
       locales.each do |locale|
         questions.row(0).push("constraint message::#{language_name(locale)} (#{locale})")
@@ -162,6 +162,9 @@ module Forms
           constraints_to_push = []
           constraint_msg_to_push = Array.new(locales.length, [])
 
+          # obtain default response values, or else an empty string
+          default_to_push = q.default || ""
+
           q.constraints.each_with_index do |c, c_index|
             constraints_to_push.push("(#{conditions_to_xls(c.conditions, c.accept_if)})")
 
@@ -216,7 +219,7 @@ module Forms
                 end
 
                 questions.row(row_index + l_index).push(name_to_push,
-                  q.required.to_s, appearance_to_push, conditions_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
+                  q.required.to_s, appearance_to_push, conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
 
                 # define the choice_filter cell for the following row, e.g, "state=${selected_state}"
                 choice_filter = "#{level_name}=${#{name_to_push}}"
@@ -237,7 +240,7 @@ module Forms
               end
 
               questions.row(row_index).push(q.code, q.required.to_s, appearance_to_push,
-                conditions_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
+                conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
             end
           else # no option set present
             # Write the question row as normal
@@ -249,7 +252,7 @@ module Forms
             end
 
             questions.row(row_index).push(q.code, q.required.to_s, appearance_to_push,
-              conditions_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
+              conditions_to_push, default_to_push, choice_filter, constraints_to_push, *constraint_msg_to_push)
           end
         end
 

--- a/app/models/forms/export.rb
+++ b/app/models/forms/export.rb
@@ -176,7 +176,11 @@ module Forms
           constraint_msg_to_push = Array.new(locales.length, [])
 
           # obtain default response values, or else an empty string
-          default_to_push = q.default || ""
+          if q.preload_last_saved
+            default_to_push = "${last-saved##{q.code}}"
+          else
+            default_to_push = q.default || ""
+          end
 
           # obtain media prompt content type and filename, if any
           # column order = image, audio, video

--- a/spec/models/forms/export_spec.rb
+++ b/spec/models/forms/export_spec.rb
@@ -23,6 +23,14 @@ describe Forms::Export do
         "3,text,#{q3.code},#{q3.name},false,false,\"\",\"\",always,\"\",,false\n"
       )
     end
+
+    it "should produce the correct xls" do
+      exporter = Forms::Export.new(simpleform)
+      q1 = simpleform.questionings[0]
+      expect(exporter.to_xls).to match("label::English \\(en\\)")
+      expect(exporter.to_xls).to match(q1.name)
+      expect(exporter.to_xls).to match(q1.code)
+    end
   end
 
   context "repeat group form with question outside repeat group before" do
@@ -98,7 +106,7 @@ describe Forms::Export do
     end
   end
 
-  context "regular group at end of form preceded by a queston outside the group" do
+  context "regular group at end of form preceded by a question outside the group" do
     let(:groupform) do
       create(
         :form,


### PR DESCRIPTION
Straightforwardly adds additional columns from NEMO question settings. Notes:

- NEMO allows you to "preload last saved answer as a default" - how is this accomplished in XLSForm? (SEE BELOW) ✅ 
- XLSForm allows you to put in a static value as a repeat count, in NEMO you must reference another question's value. ✅ 
- When uploading media_prompt files, NEMO changes the filename to a string of random numbers (e.g., `675f1bab-7de2-4527-b743-fb204c1ebcf5_media_prompt.png`). We may need to warn users because it may not be trivial to actually locate the files they have previously uploaded in order to transfer them over to the new system. Or, is there a way to locate the original filename? ✅ 
- Media_prompt column is tested and working with audio and image uploads, but i didn't have an .mp4 (only allowed video type) of under 50 MB to test with. ✅ 