### PR TITLE
12750: fixes for JS env

### DIFF
--- a/lib/tasks/theme.rake
+++ b/lib/tasks/theme.rake
@@ -18,29 +18,3 @@ namespace :theme do
     Themeing::Installer.new.run
   end
 end
-
-Rake::Task["assets:precompile"].clear
-namespace :assets do
-  # Note: Copied from capistrano-rails v1.7.0 and modified to add `env -i`
-  task :precompile do
-    on release_roles(fetch(:assets_roles)) do
-      within release_path do
-        with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
-          # execute :rake, "assets:precompile"
-
-          execute :env, "-i", "NODE_ENV=#{fetch(:node_env)}", "RAILS_ENV=#{fetch(:rails_env)}", :rake, "assets:precompile"
-
-          # execute :env, "-i",
-          #         "PATH=/usr/bin:/bin",
-          #         "HOME=#{fetch(:deploy_to)}",
-          #         "RAILS_ENV=#{fetch(:rails_env)}",
-          #         "NODE_ENV=production",
-          #         :bundle, :exec, :rake, "assets:precompile"
-        end
-      end
-    end
-  end
-end
-
-# Always need to preprocess SCSS things before precompiling.
-Rake::Task["assets:precompile"].enhance(["theme:preprocess"])

--- a/lib/tasks/theme.rake
+++ b/lib/tasks/theme.rake
@@ -19,5 +19,28 @@ namespace :theme do
   end
 end
 
+Rake::Task["assets:precompile"].clear
+namespace :assets do
+  # Note: Copied from capistrano-rails v1.7.0 and modified to add `env -i`
+  task :precompile do
+    on release_roles(fetch(:assets_roles)) do
+      within release_path do
+        with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
+          # execute :rake, "assets:precompile"
+
+          execute :env, "-i", "NODE_ENV=#{fetch(:node_env)}", "RAILS_ENV=#{fetch(:rails_env)}", :rake, "assets:precompile"
+
+          # execute :env, "-i",
+          #         "PATH=/usr/bin:/bin",
+          #         "HOME=#{fetch(:deploy_to)}",
+          #         "RAILS_ENV=#{fetch(:rails_env)}",
+          #         "NODE_ENV=production",
+          #         :bundle, :exec, :rake, "assets:precompile"
+        end
+      end
+    end
+  end
+end
+
 # Always need to preprocess SCSS things before precompiling.
 Rake::Task["assets:precompile"].enhance(["theme:preprocess"])


### PR DESCRIPTION
This small change is necessary for a larger change in a separate repo for fleet management. Anyone using open-source NEMO should double check that their automated deploy process calls `theme:preprocess` as part of the process.